### PR TITLE
fix: codecov CI/CD config

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -74,10 +74,11 @@ jobs:
           scade-version: ${{ matrix.scade-version }}
 
       - name: "Upload coverage reports to Codecov"
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4
         env:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ansys/scade-apitools
+          fail_ci_if_error: true
 
   doc-build:
     name: "Build documentation"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ansys/scade-apitools
+          files: .cov/xml
 
   doc-build:
     name: "Build documentation"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: "Upload coverage reports to Codecov"
         uses: codecov/codecov-action@v4
-        env:
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ansys/scade-apitools
           fail_ci_if_error: true

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: ansys/scade-actions/scade-tests-pytest@v1
         with:
           checkout: false
-          pytest-extra-args: "--cov=ansys --cov-report=term --cov-branch --cov-report=html:.cov/html"
+          pytest-extra-args: "--cov=ansys --cov-report=term --cov-branch --cov-report=html:.cov/html --cov-report:.cov/xml"
           scade-version: ${{ matrix.scade-version }}
 
       - name: "Upload coverage reports to Codecov"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -78,7 +78,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ansys/scade-apitools
-          fail_ci_if_error: true
 
   doc-build:
     name: "Build documentation"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: ansys/scade-actions/scade-tests-pytest@v1
         with:
           checkout: false
-          pytest-extra-args: "--cov=ansys --cov-report=term --cov-branch --cov-report=html:.cov/html --cov-report:.cov/xml"
+          pytest-extra-args: "--cov=ansys --cov-report=term --cov-branch --cov-report=html:.cov/html --cov-report=xml:.cov/xml"
           scade-version: ${{ matrix.scade-version }}
 
       - name: "Upload coverage reports to Codecov"


### PR DESCRIPTION
Ensures that silent warnings raised when uploading coverage to Codecov trigger a filed CI/CD session.