### PR TITLE
maint: support pytest 8.x

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        scade-version: ['23.1']
+        scade-version: ['23.2']
       fail-fast: false
     steps:
       - name: "Install Git and clone project"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build = [
     "twine==4.0.2"
 ]
 tests = [
-    "pytest==7.4.4",
+    "pytest==8.1.1",
     "pytest-cov==4.1.0"
 ]
 doc = [


### PR DESCRIPTION
Remove the tests with Python3.7 e.g., SCADE 2023 R1, to be compatible with pytest 8.x