### PR TITLE
fix: Fix the directive clean for the documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,6 +7,7 @@ SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build
 APIDIR        = api
+EXAMPLESDIR   = _examples
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -24,6 +25,7 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	find . -type d -name $(APIDIR) -exec rm -rf {} +
+	find . -type d -name $(EXAMPLESDIR) -exec rm -rf {} +
 
 # Customized pdf for svg format images
 pdf:

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -10,6 +10,7 @@ if "%SPHINXBUILD%" == "" (
 set SOURCEDIR=source
 set BUILDDIR=_build
 set APIDIR=api
+set EXAMPLESDIR=_examples
 
 if "%1" == "" goto help
 if "%1" == "clean" goto clean
@@ -32,7 +33,7 @@ goto end
 
 :clean
 rmdir /s /q %BUILDDIR% > /NUL 2>&1
-for /d /r %SOURCEDIR% %%d in (%APIDIR) do @if exist "%%d" rmdir /s /q "%%d"
+for /d /r %SOURCEDIR% %%d in (%APIDIR% %EXAMPLESDIR%) do @if exist "%%d" rmdir /s /q "%%d"
 goto end
 
 :help


### PR DESCRIPTION
The command `make clean` should delete the directories api and _examples that are auto-generated.