### PR TITLE
Set the interval of dependabot to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     labels:
       - "maintenance"
       - "dependencies"
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     labels:
       - "maintenance"
     groups:


### PR DESCRIPTION
The current activity on the project does not require weekly updates.