### PR TITLE
chore: Enable Python 3.12 and greater

### DIFF
--- a/doc/changelog.d/104.test.md
+++ b/doc/changelog.d/104.test.md
@@ -1,0 +1,1 @@
+chore: Enable Python 3.12 and greater

--- a/doc/changelog.d/changelog_template.jinja
+++ b/doc/changelog.d/changelog_template.jinja
@@ -1,17 +1,22 @@
 {% if sections[""] %}
-{% for category, val in definitions.items() if category in sections[""] %}
 
-{{ definitions[category]['name'] }}
-{% set underline = '^' * definitions[category]['name']|length %}
-{{ underline }}
+.. tab-set::
+
+{%+ for category, val in definitions.items() if category in sections[""] %}
+
+  .. tab-item:: {{ definitions[category]['name'] }}
+
+    .. list-table::
+        :header-rows: 0
+        :widths: auto
 
 {% for text, values in sections[""][category].items() %}
-- {{ text }} {{ values|join(', ') }}
-{% endfor %}
+        * - {{ text }}
+          - {{ values|join(', ') }}
 
 {% endfor %}
+{% endfor %}
+
 {% else %}
 No significant changes.
-
-
 {% endif %}

--- a/doc/source/examples/info/output_get_scade_home.txt
+++ b/doc/source/examples/info/output_get_scade_home.txt
@@ -1,1 +1,1 @@
-SCADE installation directory: c:\Program Files\ANSYS Inc\v232\SCADE
+SCADE installation directory: C:\Program Files\ANSYS Inc\v232\SCADE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,10 @@ build = [
     "twine==6.1.0"
 ]
 tests = [
-    "pytest==8.3.4",
-    "pytest-cov==6.0.0"
+    "pytest==7.4.0; python_version < '3.8'",
+    "pytest-cov==4.1.0; python_version < '3.8'",
+    "pytest==8.3.4; python_version >= '3.8'",
+    "pytest-cov==6.0.0; python_version >= '3.8'",
 ]
 doc = [
     "ansys-sphinx-theme[autoapi]==1.3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ version="0.5.dev0"
 description ="An extension library for SCADE Python APIs."
 readme="README.rst"
 
-# only 3.7. and 3.10
-requires-python = ">=3.7,!=3.8.*,!=3.9.*,<3.11"
+# only 3.7, 3.10, or >= 3.12
+requires-python = ">=3.7,!=3.8.*,!=3.9.*,!=3.11.*"
 license = {file = "LICENSE"}
 authors = [
     {name = "Ansys, Inc.", email = "pyansys.core@ansys.com"},

--- a/src/ansys/scade/apitools/auto_scade_env.py
+++ b/src/ansys/scade/apitools/auto_scade_env.py
@@ -58,7 +58,7 @@ def _get_scade_dirs(min='00.0', max='99.9'):
     if platform.system() == 'Windows':
         for company in 'Esterel Technologies', 'Ansys Inc':
             try:
-                hklm = reg.OpenKey(reg.HKEY_LOCAL_MACHINE, 'SOFTWARE\%s\SCADE' % company)
+                hklm = reg.OpenKey(reg.HKEY_LOCAL_MACHINE, r'SOFTWARE\%s\SCADE' % company)
             except OSError:
                 continue
             for i in range(reg.QueryInfoKey(hklm)[0]):
@@ -82,9 +82,11 @@ def _get_python_scade_versions(python_version: str):
     releases = {
         '3.4': ('19.2', '21.2'),
         '3.7': ('21.2', '23.2'),
-        '3.10': ('23.2', '99.9'),
+        '3.10': ('23.2', '26.1'),
+        '3.12': ('26.1', '99.9'),
     }
-    interval = releases.get(python_version)
+    # starting 26.1, usage of 3.12 ABI
+    interval = releases.get(python_version) if python_version < '3.12' else ('26.1', '99.9')
     return interval
 
 
@@ -122,6 +124,7 @@ def _add_scade_to_sys_path():
     if not home:  # pragma no cover
         # wrong installation or SCADE not available on the computer
         print('Use a Python interpreter delivered with SCADE.')
+        assert False
     else:
         # regular SCADE installation
         _base = home / 'SCADE'

--- a/src/ansys/scade/apitools/auto_scade_env.py
+++ b/src/ansys/scade/apitools/auto_scade_env.py
@@ -47,7 +47,7 @@ def _resolve_venv(home: Path) -> Optional[Path]:
     cfg = home / 'pyvenv.cfg'
     if cfg.exists():
         for line in cfg.open('r'):
-            m = re.match('^home\s*=\s*(.*)$', line)
+            m = re.match(r'^home\s*=\s*(.*)$', line)
             if m:
                 return Path(m.groups()[0]).parent
     return None

--- a/src/ansys/scade/apitools/auto_scade_env.py
+++ b/src/ansys/scade/apitools/auto_scade_env.py
@@ -88,8 +88,10 @@ def _get_python_scade_versions(major: int, minor: int):
     }
     if major != 3:
         return None
-    # starting 26.1, usage of 3.12 ABI
-    interval = releases.get(minor) if minor < 12 else ('26.1', '99.9')
+    if minor > 12:
+        # starting 3.12, SCADE uses the Python Limited API
+        minor = 12
+    interval = releases.get(minor)
     return interval
 
 

--- a/src/ansys/scade/apitools/auto_scade_env.py
+++ b/src/ansys/scade/apitools/auto_scade_env.py
@@ -126,7 +126,6 @@ def _add_scade_to_sys_path():
     if not home:  # pragma no cover
         # wrong installation or SCADE not available on the computer
         print('Use a Python interpreter delivered with SCADE.')
-        assert False
     else:
         # regular SCADE installation
         _base = home / 'SCADE'

--- a/tests/test_auto_scade_env.py
+++ b/tests/test_auto_scade_env.py
@@ -36,7 +36,7 @@ Test strategy:
 import pytest
 
 # shall modify sys.path to access SCADE APIs
-import ansys.scade.apitools as apitools
+from ansys.scade.apitools.auto_scade_env import _get_compatible_scade_home
 
 
 def test_auto_scade_env():
@@ -47,19 +47,18 @@ def test_auto_scade_env():
 
 
 @pytest.mark.parametrize(
-    'tc',
+    'versions, status',
     [
-        (['2.7', '3.8'], False),
-        (['3.4', '3.7', '3.10', '3.12', '3.13'], True),
+        ([(2, 7), (3, 8)], False),
+        ([(3, 4), (3, 7), (3, 10), (3, 12), (3, 13)], True),
     ],
 )
-def test_get_compatible_scade_home(tc):
-    # make sure at least one SCADE version is available for one of 3.4, 3.7, 3.10
+def test_get_compatible_scade_home(versions, status):
+    # make sure at least one SCADE version is available for one of 3.4, 3.7, 3.10, etc.
     # and not available for a few other versions
-    versions, status = tc
     homes = []
-    for version in versions:
-        home = apitools.auto_scade_env._get_compatible_scade_home(version)
+    for major, minor in versions:
+        home = _get_compatible_scade_home(major, minor)
         if home:
             homes.append(home)
     assert (len(homes) != 0) == status

--- a/tests/test_auto_scade_env.py
+++ b/tests/test_auto_scade_env.py
@@ -50,7 +50,7 @@ def test_auto_scade_env():
     'tc',
     [
         (['2.7', '3.8'], False),
-        (['3.4', '3.7', '3.10'], True),
+        (['3.4', '3.7', '3.10', '3.12', '3.13'], True),
     ],
 )
 def test_get_compatible_scade_home(tc):

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -36,6 +36,7 @@ to some expected result, nor easy to maintain.
 Anyways, the result projects can be exmined after the execution of the tests, for a deep analysis.
 """
 
+from pathlib import Path
 from typing import List, Union
 
 import pytest
@@ -119,7 +120,7 @@ class TestCreateProject:
     @pytest.mark.parametrize(
         'path, persist_as',
         nominal_file_ref_data,
-        ids=['%s-%s' % (_[0], _[1]) for _ in nominal_file_ref_data],
+        ids=['%s-%s' % (_[0], Path(_[1]).name) for _ in nominal_file_ref_data],
     )
     def test_create_file_ref(self, tmp_project_session, path, persist_as):
         # project/session must have been duplicated to a temporary directory

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,47 @@
 [tox]
 description = Default tox environments list
-env_list = style, tests-coverage, doc-html
+env_list = code-style, py{37, 310, 312}-tests{-coverage,}, doc-{links, html}
 skip_missing_interpreters = true
-isolated_build = true
 isolated_build_env = build
 
-[testenv:tests{-coverage,}]
-description = Checks for project unit tests and coverage (if desired)
+[testenv:py{37, 310, 312}-tests{-coverage,}]
+description =
+    Checks for project unit tests
+    coverage: and coverage
+    py37: with python version 3.7
+    py310: with python version 3.10
+    py312: with python version 3.12
 base_python =
-    python3.10
-extras =
-    tests
+    py37: python3.7
+    py310: python3.10
+    py312: python3.12
+download = true
+extras = tests
 setenv =
+    TEMP = {env_tmp_dir}
+    TMP = {env_tmp_dir}
     PYTHONUNBUFFERED = yes
-    coverage: PYTEST_EXTRA_ARGS = --cov=ansys.scade --cov-report=term --cov-report=xml:.cov/xml --cov-report=html:.cov/html --cov-branch
+    coverage: COVERAGE_FILE = {work_dir}/.cov/.coverage.{env_name}
+    coverage: PYTEST_EXTRA_ARGS = --cov=ansys.scade --cov-report=term --cov-report=xml:.cov/.{env_name}/xml --cov-report=html:.cov/.{env_name}/html --cov-branch
 commands =
-    pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    python -m pytest -o addopts= {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
-[testenv:style]
+[testenv:code-style]
 description = Checks project code style
+base_python = python3
 skip_install = true
 deps = pre-commit
 commands =
-    pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
 [testenv:doc-{links,html}]
-description = Check if documentation links generate properly
-extras =
-    doc
+description =
+    Checks
+    links: the integrity of all external links
+    html: if html documentation generates properly
+extras = doc
 setenv =
-    links: SPHINXBUILDER = linkcheck
-    html: SPHINXBUILDER = html
+    links: BUILDER = linkcheck
+    html: BUILDER = html
 commands =
-    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxinidir}/doc/_build/{env:SPHINXBUILDER}" --color -vW -b{env:SPHINXBUILDER}
+    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxinidir}/doc/_build/{env:BUILDER}" --color -vW -b{env:BUILDER} -j auto --keep-going


### PR DESCRIPTION
Prepare the package for SCADE 2026 R1 that uses Python 3.12.
* Python 3.12 support
* `tox.ini` updates for explicit tests using 3.7, 3.10 and 3.12