### PR TITLE
ci: Fix release steps

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -156,6 +156,7 @@ jobs:
       - name: "Release to GitHub"
         uses: ansys/actions/release-github@v8
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           library-name: ${{ env.LIBRARY_NAME }}
           additional-artifacts: 'examples'
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -134,6 +134,7 @@ jobs:
     steps:
       - uses: ansys/actions/doc-deploy-changelog@v8
         with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}

--- a/doc/changelog.d/105.maintenance.md
+++ b/doc/changelog.d/105.maintenance.md
@@ -1,0 +1,1 @@
+ci: Fix release steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.2,<3.11"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
* Limit flit version
* Specify the version of Python for updating the change log
* Add missing `token` input for releasing to GitHub