### PR TITLE
fix: Update typing annotations and fix linter errors.

### DIFF
--- a/doc/changelog.d/115.maintenance.md
+++ b/doc/changelog.d/115.maintenance.md
@@ -1,0 +1,1 @@
+Fix: update typing annotations and fix linter errors.

--- a/doc/source/create/res/create_constant/debug_create_constant.py
+++ b/doc/source/create/res/create_constant/debug_create_constant.py
@@ -22,6 +22,7 @@ if target_dir.exists():
 copytree(source_dir, target_dir)
 
 # declare the duplicated model
+assert declare_project  # nosec
 declare_project(str(target_dir / 'Model.etp'))
 
 # regular script

--- a/doc/source/create/res/create_package/debug_create_package.py
+++ b/doc/source/create/res/create_package/debug_create_package.py
@@ -22,6 +22,7 @@ if target_dir.exists():
 copytree(source_dir, target_dir)
 
 # declare the duplicated model
+assert declare_project  # nosec
 declare_project(str(target_dir / 'Model.etp'))
 
 # regular script

--- a/doc/source/create/res/create_type/debug_create_type.py
+++ b/doc/source/create/res/create_type/debug_create_type.py
@@ -22,6 +22,7 @@ if target_dir.exists():
 copytree(source_dir, target_dir)
 
 # declare the duplicated model
+assert declare_project  # nosec
 declare_project(str(target_dir / 'Model.etp'))
 
 # regular script

--- a/examples/create/if_block/debug_create_if_block.py
+++ b/examples/create/if_block/debug_create_if_block.py
@@ -44,6 +44,7 @@ if target_dir.exists():
 copytree(source_dir, target_dir)
 
 # declare the duplicated model
+assert declare_project  # nosec
 declare_project(str(target_dir / 'Empty.etp'))
 
 # regular script

--- a/examples/create/interface/create_interface.py
+++ b/examples/create/interface/create_interface.py
@@ -41,6 +41,7 @@ Usage::
 """
 
 from pathlib import Path
+from typing import Optional
 
 import scade.model.project.stdproject as std
 import scade.model.suite as suite
@@ -148,7 +149,7 @@ def create_interface(project: std.Project, model: suite.Model, description: Path
     create.save_all()
 
 
-def main(description: Path = None):
+def main(description: Optional[Path] = None):
     """
     Create the operators and their interface into the model.
 
@@ -165,8 +166,9 @@ def main(description: Path = None):
     # note: the script shall be launched with a single project
     project = std.get_roots()[0]
     session = suite.get_roots()[0]
-    # the description file is in the same directory
-    description = Path(__file__).with_name('interface.txt')
+    if not description:
+        # the description file is in the same directory
+        description = Path(__file__).with_name('interface.txt')
     # cache all the types of the model and its libraries
     cache_types(session)
     # create the interface from the description file

--- a/examples/create/interface/debug_create_interface.py
+++ b/examples/create/interface/debug_create_interface.py
@@ -44,6 +44,7 @@ if target_dir.exists():
 copytree(source_dir, target_dir)
 
 # declare the duplicated model
+assert declare_project  # nosec
 declare_project(str(target_dir / 'Project.etp'))
 
 # regular script

--- a/examples/create/make/debug_create_make.py
+++ b/examples/create/make/debug_create_make.py
@@ -44,6 +44,7 @@ if target_dir.exists():
 copytree(source_dir, target_dir)
 
 # declare the duplicated model
+assert declare_project  # nosec
 declare_project(str(target_dir / 'Empty.etp'))
 
 # regular script

--- a/examples/create/state_machine/create_state_machine.py
+++ b/examples/create/state_machine/create_state_machine.py
@@ -29,6 +29,8 @@ Usage::
 
 """
 
+from typing import List, Tuple
+
 import scade.model.suite as suite
 
 import ansys.scade.apitools.create as create
@@ -43,12 +45,12 @@ def main():
     # assume the operator has a graphical diagram
     diagram = operator.diagrams[0]
     # hard coded SM with three states
-    position = [500, 500]
-    size = [15000, 5000]
+    position = (500, 500)
+    size = (15000, 5000)
     sm = create.add_data_def_state_machine(operator, 'SM', diagram, position, size)
     # states
-    positions = [[6000, 1000], [1000, 4000], [11000, 4000]]
-    size = [4000, 1000]
+    positions = [(6000, 1000), (1000, 4000), (11000, 4000)]
+    size = (4000, 1000)
     states = []
     for kind, display, position in zip(create.SK, create.DK, positions):
         state = create.add_state_machine_state(sm, kind.value, position, size, kind, display)
@@ -59,7 +61,7 @@ def main():
     # create a transition from initial to final
     # let the tool compute default positions/size for the label
     # no help from the tool for the points, we must provide consistent positions
-    points = [(5000, 4500), (6000, 4000), (10000, 5000), (11000, 4500)]
+    points: List[Tuple[float, float]] = [(5000, 4500), (6000, 4000), (10000, 5000), (11000, 4500)]
     tree = create.create_transition_state(True, final, False, 1, points, polyline=False)
     create.add_state_transition(initial, create.TK.STRONG, tree)
 

--- a/examples/create/state_machine/debug_create_state_machine.py
+++ b/examples/create/state_machine/debug_create_state_machine.py
@@ -44,6 +44,7 @@ if target_dir.exists():
 copytree(source_dir, target_dir)
 
 # declare the duplicated model
+assert declare_project  # nosec
 declare_project(str(target_dir / 'Empty.etp'))
 
 # regular script

--- a/examples/create/top_level/debug_create_top_level.py
+++ b/examples/create/top_level/debug_create_top_level.py
@@ -44,6 +44,7 @@ if target_dir.exists():
 copytree(source_dir, target_dir)
 
 # declare the duplicated model
+assert declare_project  # nosec
 declare_project(str(target_dir / 'Project.etp'))
 
 # regular script

--- a/examples/create/when_block/create_when_block.py
+++ b/examples/create/when_block/create_when_block.py
@@ -47,7 +47,7 @@ def main():
 
     # hard coded WB with three actions
     positions = [(2300, 2000), (7000, 3500), (2300, 4500)]
-    size = [4000, 1000]
+    size = (4000, 1000)
     branches = []
     for pattern, position in zip(e.type.type.values, positions):
         branch = create.create_when_branch(pattern.name, position, size)

--- a/examples/create/when_block/debug_create_when_block.py
+++ b/examples/create/when_block/debug_create_when_block.py
@@ -44,6 +44,7 @@ if target_dir.exists():
 copytree(source_dir, target_dir)
 
 # declare the duplicated model
+assert declare_project  # nosec
 declare_project(str(target_dir / 'Empty.etp'))
 
 # regular script

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ Homepage = "https://www.ansys.com/products/embedded-software/ansys-scade-suite"
 
 [tool.ruff]
 line-length = 99
+
+[tool.ruff.lint]
 select = [
     "E",    # pycodestyle, see https://beta.ruff.rs/docs/rules/#pycodestyle-e-w
     "D",    # pydocstyle, see https://beta.ruff.rs/docs/rules/#pydocstyle-d
@@ -87,7 +89,7 @@ ignore = [
 [tool.ruff.format]
 quote-style = "preserve"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 force-sort-within-sections = true
 known-first-party = ["ansys", "conftest", "test_utils"]

--- a/src/ansys/scade/apitools/create/data_def.py
+++ b/src/ansys/scade/apitools/create/data_def.py
@@ -27,6 +27,7 @@ Provides create functions for Scade operator definitions.
 * Behavior
 """
 
+from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List, Optional, Sequence, Tuple, Union
 
@@ -998,7 +999,7 @@ def _build_transition(src: Union[suite.State, suite.Transition], tree: TR) -> su
         transition.target = td.state
         transition.reset_target = td.reset
     else:
-        assert isinstance(td, _Fork)
+        assert isinstance(td, _Fork)  # nosec B101  # addresses linter
         for fork in td.transitions:
             _build_transition(transition, fork)
 
@@ -1044,7 +1045,7 @@ def add_transition_equation(
 # if blocks
 
 
-class IfTree:
+class IfTree(ABC):
     """Provides an intermediate structure for describing the structure of an if block."""
 
     def __init__(self, position: Tuple[float, float] = (0, 0)):
@@ -1053,10 +1054,10 @@ class IfTree:
         # name to be used if a diagram needs to be created
         self.name = ''
 
+    @abstractmethod
     def _build(self, context: suite.Object, diagram: suite.Diagram) -> suite.IfBranch:
         """Build an if branch from the tree."""
-        # must be overridden
-        assert False  # pragma no cover
+        raise NotImplementedError  # pragma no cover
 
 
 IT = IfTree

--- a/src/ansys/scade/apitools/create/data_def.py
+++ b/src/ansys/scade/apitools/create/data_def.py
@@ -28,7 +28,7 @@ Provides create functions for Scade operator definitions.
 """
 
 from enum import Enum
-from typing import List, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import scade.model.suite as suite
 
@@ -265,7 +265,7 @@ def add_data_def_net_diagram(data_def: suite.DataDef, name: str) -> suite.NetDia
 # equations and edges
 
 
-def _num_to_str(values: List[Union[int, float]]) -> List[str]:
+def _num_to_str(values: Sequence[Union[int, float]]) -> List[str]:
     """SCADE graphical coordinates are strings: position, size, points."""
     return [str(_) for _ in values]
 
@@ -299,11 +299,11 @@ def _create_internal(data_def: suite.DataDef, tree: TX) -> suite.LocalVariable:
 
 def add_data_def_equation(
     data_def: suite.DataDef,
-    diagram: suite.Diagram,
-    lefts: List[Union[suite.LocalVariable, TX]],
-    right: EX,
-    position: Tuple[float, float] = None,
-    size: Tuple[float, float] = None,
+    diagram: Optional[suite.Diagram],
+    lefts: Sequence[Union[suite.LocalVariable, TX]],
+    right: Optional[EX],
+    position: Tuple[float, float] = (0, 0),
+    size: Tuple[float, float] = (0, 0),
     symmetrical: bool = False,
     rotation: int = 0,
     textual: bool = False,
@@ -315,21 +315,21 @@ def add_data_def_equation(
     ----------
     data_def : suite.DataDef
         Input scope, which is an operator, state, or action.
-    diagram : suite.Diagram
+    diagram : suite.Diagram | None
         Diagram containing the equation. The diagram specified can be either graphical
         or textual, or it can be ``None``. However, it cannot be ``None`` if the scope
         contains at least one diagram.
-    lefts : List[Union[suite.LocalVariable, TX]]
+    lefts : Sequence[Union[suite.LocalVariable, TX]]
         List of variables defined by the equation. The elements can be either an
         existing local variable or a type tree to create an internal
         variable on the fly when the diagram is a graphical diagram.
-    right : EX
+    right : EX | None
         Expression of the equation.
-    position : Tuple[float, float], default: None
+    position : Tuple[float, float], default: (0, 0))
         Position of the equation, expressed in 1/100th of mm.
         This value is ignored if the diagram is not a graphical diagram.
         Otherwise, it must be specified.
-    size : Tuple[float, float], default: None
+    size : Tuple[float, float], default: (0, 0)
         Size of the equation, expressed in 1/100th of mm.
         This value is ignored if the diagram is not a graphical diagram.
         Otherwise, it must be specified.
@@ -376,7 +376,8 @@ def add_data_def_equation(
 
         equation.lefts.append(variable)
 
-    equation.right = _build_expression(right, data_def)
+    if right is not None:
+        equation.right = _build_expression(right, data_def)
 
     # graphical part
     if diagram and not isinstance(data_def, suite.Operator):
@@ -414,7 +415,7 @@ def add_diagram_edge(
     left: suite.LocalVariable,
     dst: suite.Equation,
     expr: Union[int, suite.Expression],
-    points: List[Tuple[int, int]] = None,
+    points: Optional[List[Tuple[int, int]]] = None,
 ) -> suite.Edge:
     """
     Add a graphical edge between two equations in a graphical diagram.
@@ -444,7 +445,7 @@ def add_diagram_edge(
         Target equation of the edge.
     expr: Union[suite.Expression]
         Parameter to connect to the edge or the input pin index of the target equation.
-    points : List[Tuple(int, int)], default: None
+    points : List[Tuple(int, int)] | None, default: None
         Coordinates of the segments composing the edge, expressed in 1/100th of mm.
         When ``None``, the value is set to ``[(0, 0), (0, 0)]`` so that the SCADE Editor
         computes default positions when the model is loaded.
@@ -551,11 +552,11 @@ class AK(Enum):
 
 def add_data_def_assertion(
     data_def: suite.DataDef,
-    diagram: suite.Diagram,
+    diagram: Optional[suite.Diagram],
     name: str,
     expr: EX,
     kind: AK = AK.ASSUME,
-    position: Tuple[float, float] = None,
+    position: Tuple[float, float] = (0, 0),
 ) -> suite.Assertion:
     """
     Create an assertion in a scope.
@@ -564,7 +565,7 @@ def add_data_def_assertion(
     ----------
     data_def : suite.DataDef
         Input scope, which is an operator, state, or action.
-    diagram : suite.Diagram
+    diagram : suite.Diagram | None
         Diagram containing the equation. The diagram specified can be either graphical
         or textual, or it can be ``None``. However, it cannot be ``None`` if the scope
         contains at least one diagram.
@@ -574,7 +575,7 @@ def add_data_def_assertion(
         Expression of the assertion.
     kind : AK, default: ASSUME
         Kind of the assertion.
-    position : Tuple[float, float], default: None
+    position : Tuple[float, float], default: (0, 0)
         Position of the assertion, expressed in 1/100th of mm.
         This value is ignored if the diagram is not a graphical diagram.
         Otherwise, it must be specified.
@@ -622,8 +623,8 @@ def add_data_def_state_machine(
     data_def: suite.DataDef,
     name: str,
     diagram: suite.Diagram,
-    position: Tuple[float, float] = None,
-    size: Tuple[float, float] = None,
+    position: Tuple[float, float] = (0, 0),
+    size: Tuple[float, float] = (0, 0),
 ) -> suite.StateMachine:
     """
     Create a state machine in a scope.
@@ -701,8 +702,8 @@ class DK(Enum):
 def add_state_machine_state(
     sm: suite.StateMachine,
     name: str,
-    position: Tuple[float, float] = None,
-    size: Tuple[float, float] = None,
+    position: Tuple[float, float] = (0, 0),
+    size: Tuple[float, float] = (0, 0),
     kind: SK = SK.NORMAL,
     display: DK = DK.GRAPHICAL,
 ) -> suite.State:
@@ -715,11 +716,11 @@ def add_state_machine_state(
         Input state machine.
     name : str.StateMachine
         Name of the state.
-    position : Tuple[float, float], default: None
+    position : Tuple[float, float], default: (0, 0)
         Position of the state, expressed in 1/100th of mm.
         This value is considered if and only if the state machine
         has a graphical representation.
-    size : Tuple[float, float], default: None
+    size : Tuple[float, float], default: (0, 0)
         Size of the state, expressed in 1/100th of mm.
         This value is considered if and only if the state machine
         has a graphical representation.
@@ -779,13 +780,13 @@ class TransitionTree:
 
     def __init__(
         self,
-        trigger: EX,
+        trigger: Optional[EX],
         target: TD,
         priority: int,
-        points: List[Tuple[float, float]] = None,
-        label_position: Tuple[float, float] = None,
-        label_size: Tuple[float, float] = None,
-        slash_position: Tuple[float, float] = None,
+        points: Optional[List[Tuple[float, float]]] = None,
+        label_position: Tuple[float, float] = (0, 0),
+        label_size: Tuple[float, float] = (0, 0),
+        slash_position: Tuple[float, float] = (0, 0),
         polyline: bool = True,
     ):
         """Store the attributes."""
@@ -793,11 +794,11 @@ class TransitionTree:
         self.target = target
         self.priority = priority
         # the points must be provided for graphical representations
-        self.points = points
+        self.points = points if points else []
         # the positions and sizes are optional
-        self.label_position = label_position if label_position else [0, 0]
-        self.label_size = label_size if label_size else [0, 0]
-        self.slash_position = slash_position if slash_position else [0, 0]
+        self.label_position = label_position
+        self.label_size = label_size
+        self.slash_position = slash_position
         self.polyline = polyline
 
 
@@ -831,14 +832,14 @@ class TK(Enum):
 
 
 def create_transition_state(
-    trigger: EX,
+    trigger: Optional[EX],
     state: suite.State,
     reset: bool,
     priority: int,
-    points: List[Tuple[float, float]] = None,
-    label_position: Tuple[float, float] = None,
-    label_size: Tuple[float, float] = None,
-    slash_position: Tuple[float, float] = None,
+    points: Optional[List[Tuple[float, float]]] = None,
+    label_position: Tuple[float, float] = (0, 0),
+    label_size: Tuple[float, float] = (0, 0),
+    slash_position: Tuple[float, float] = (0, 0),
     polyline: bool = True,
 ) -> TR:
     """
@@ -851,7 +852,7 @@ def create_transition_state(
 
     Parameters
     ----------
-    trigger : EX
+    trigger : EX | None
         Extended expression tree defining the trigger of the transition.
     state : suite.State
         Target state of the transition.
@@ -859,13 +860,13 @@ def create_transition_state(
         Whether the transition resets the targtet state.
     priority : int
         Priority of the transition.
-    points : List[Tuple[float, float]], default: None
+    points : List[Tuple[float, float]] | None, default: None
         Points of the transition.
-    label_position : Tuple[float, float], default: None
+    label_position : Tuple[float, float], default: (0, 0)
         Position of the label.
-    label_size : Tuple[float, float], default: None
+    label_size : Tuple[float, float], default: (0, 0)
         Size of the label.
-    slash_position : Tuple[float, float], default: None
+    slash_position : Tuple[float, float], default: (0, 0)
         Position of the separator between the trigger and the action
         of the transition.
     polyline : bool, default: True
@@ -881,13 +882,13 @@ def create_transition_state(
 
 
 def create_transition_fork(
-    trigger: EX,
+    trigger: Optional[EX],
     forks: List[TR],
     priority: int,
-    points: List[Tuple[float, float]] = None,
-    label_position: Tuple[float, float] = None,
-    label_size: Tuple[float, float] = None,
-    slash_position: Tuple[float, float] = None,
+    points: Optional[List[Tuple[float, float]]] = None,
+    label_position: Tuple[float, float] = (0, 0),
+    label_size: Tuple[float, float] = (0, 0),
+    slash_position: Tuple[float, float] = (0, 0),
     polyline: bool = True,
 ) -> TR:
     """
@@ -900,19 +901,19 @@ def create_transition_fork(
 
     Parameters
     ----------
-    trigger : EX
+    trigger : EX | None
         Extended expression tree defining the trigger of the transition.
     forks : List[TR]
         Transitions forked from this transition.
     priority : int
         Priority of the transition.
-    points : List[Tuple[float, float]], default: None
+    points : List[Tuple[float, float]] | None, default: None
         Points of the transition.
-    label_position : Tuple[float, float], default: None
+    label_position : Tuple[float, float], default: (0, 0)
         Position of the label.
-    label_size : Tuple[float, float], default: None
+    label_size : Tuple[float, float], default: (0, 0)
         Size of the label, default: None
-    slash_position : Tuple[float, float], default: None
+    slash_position : Tuple[float, float], default: (0, 0)
         Position of the separator between the trigger and the action
         of the transition.
     polyline : bool, default: True
@@ -1007,7 +1008,7 @@ def _build_transition(src: Union[suite.State, suite.Transition], tree: TR) -> su
 def add_transition_equation(
     transition: suite.Transition,
     lefts: List[Union[suite.LocalVariable, TX]],
-    right: EX,
+    right: Optional[EX],
 ) -> suite.Equation:
     """
     Create an equation in a transition.
@@ -1023,7 +1024,7 @@ def add_transition_equation(
         Input transition.
     lefts : List[suite.LocalVariable]
         List of variables defined by the equation.
-    right : EX
+    right : EX | None
         Expression of the equation.
 
     Returns
@@ -1046,11 +1047,11 @@ def add_transition_equation(
 class IfTree:
     """Provides an intermediate structure for describing the structure of an if block."""
 
-    def __init__(self, position: Tuple[float, float] = None):
+    def __init__(self, position: Tuple[float, float] = (0, 0)):
         """Store the attributes."""
-        self.position = position if position else (0, 0)
+        self.position = position
         # name to be used if a diagram needs to be created
-        self.name = None
+        self.name = ''
 
     def _build(self, context: suite.Object, diagram: suite.Diagram) -> suite.IfBranch:
         """Build an if branch from the tree."""
@@ -1070,7 +1071,7 @@ class _Node(IT):
         expression: EX,
         then: IT,
         else_: IT,
-        position: Tuple[float, float] = None,
+        position: Tuple[float, float] = (0, 0),
         label_width: int = 0,
     ):
         """Store the attributes."""
@@ -1108,8 +1109,8 @@ class _Action(IT):
 
     def __init__(
         self,
-        position: Tuple[float, float] = None,
-        size: Tuple[float, float] = None,
+        position: Tuple[float, float] = (0, 0),
+        size: Tuple[float, float] = (0, 0),
         display: DK = DK.GRAPHICAL,
     ):
         """Store the attributes."""
@@ -1140,8 +1141,8 @@ class _Action(IT):
 
 
 def create_if_action(
-    position: Tuple[float, float] = None,
-    size: Tuple[float, float] = None,
+    position: Tuple[float, float] = (0, 0),
+    size: Tuple[float, float] = (0, 0),
     display: DK = DK.GRAPHICAL,
 ) -> IT:
     """
@@ -1154,9 +1155,9 @@ def create_if_action(
 
     Parameters
     ----------
-    position : Tuple[float, float], default: None
+    position : Tuple[float, float], default: (0, 0)
         Position of the action.
-    size : Tuple[float, float], default: None
+    size : Tuple[float, float], default: (0, 0)
         Size of the action.
     display : DK, default: GRAPHICAL
         Layout of the action.
@@ -1170,7 +1171,11 @@ def create_if_action(
 
 
 def create_if_tree(
-    expression: EX, then: IT, else_: IT, position: Tuple[float, float] = None, label_width: int = 0
+    expression: EX,
+    then: IT,
+    else_: IT,
+    position: Tuple[float, float] = (0, 0),
+    label_width: int = 0,
 ) -> IT:
     r"""
     Create a decision in the intermediate structure if it is a tree structure.
@@ -1191,7 +1196,7 @@ def create_if_tree(
         Sub-decision tree to consider when the condition is ``True``.
     else\_ : IT
         Sub-decision tree to consider when the condition is ``False``.
-    position : Tuple[float, float], default: None
+    position : Tuple[float, float], default: (0, 0)
         Position of the decision.
     label_width : int, default: 0
         Size of the label.
@@ -1208,8 +1213,8 @@ def add_data_def_if_block(
     name: str,
     if_tree: IfTree,
     diagram: suite.Diagram,
-    position: Tuple[float, float] = None,
-    size: Tuple[float, float] = None,
+    position: Tuple[float, float] = (0, 0),
+    size: Tuple[float, float] = (0, 0),
 ) -> suite.IfBlock:
     """
     Create an if block in a scope.
@@ -1230,9 +1235,9 @@ def add_data_def_if_block(
         Diagram containing the equation. The diagram specified can be either graphical
         or textual, or it can be ``None``. However, it cannot be ``None`` if the scope
         contains at least one diagram.
-    position : Tuple[float, float], default: None
+    position : Tuple[float, float], default: (0, 0)
         Position of the if block.
-    size : Tuple[float, float], default: None
+    size : Tuple[float, float], default: (0, 0)
         Size of the if block.
 
     Returns
@@ -1280,23 +1285,23 @@ class WhenBranch:
     def __init__(
         self,
         pattern: EX,
-        position: Tuple[float, float] = None,
-        size: Tuple[float, float] = None,
+        position: Tuple[float, float] = (0, 0),
+        size: Tuple[float, float] = (0, 0),
         display: DK = DK.GRAPHICAL,
         label_width: int = 0,
     ):
         """Store the attributes."""
         self.pattern = pattern
-        self.position = position if position else [0, 0]
-        self.size = size if size else [0, 0]
+        self.position = position
+        self.size = size
         self.display = display
         self.label_width = label_width
 
 
 def create_when_branch(
     pattern: EX,
-    position: Tuple[float, float] = None,
-    size: Tuple[float, float] = None,
+    position: Tuple[float, float] = (0, 0),
+    size: Tuple[float, float] = (0, 0),
     display: DK = DK.GRAPHICAL,
     label_width: int = 0,
 ) -> WhenBranch:
@@ -1312,9 +1317,9 @@ def create_when_branch(
     ----------
     pattern : EX
         Value of the branch.
-    position : Tuple[float, float], default: None
+    position : Tuple[float, float], default: (0, 0)
         Position of the action.
-    size : Tuple[float, float], default: None
+    size : Tuple[float, float], default: (0, 0)
         Size of the action.
     display : DK, default: GRAPHICAL
         Layout of the action.
@@ -1333,9 +1338,9 @@ def add_data_def_when_block(
     name: str,
     when: EX,
     branches: List[WhenBranch],
-    diagram: suite.Diagram = None,
-    position: Tuple[float, float] = None,
-    size: Tuple[float, float] = None,
+    diagram: Optional[suite.Diagram] = None,
+    position: Tuple[float, float] = (0, 0),
+    size: Tuple[float, float] = (0, 0),
     start_position: Tuple[float, float] = (450, 582),
     label_width: int = 0,
 ) -> suite.WhenBlock:
@@ -1358,13 +1363,13 @@ def add_data_def_when_block(
     branches : List[WhenBranch]
         List of intermediate structures describing the branches.
         There must be at least one branch.
-    diagram : suite.Diagram, default: None
+    diagram : suite.Diagram | None, default: None
         Diagram containing the equation. The diagram specified can be either graphical
         or textual, or it can be ``None``. However, it cannot be ``None`` if the scope
         contains at least one diagram.
-    position : Tuple[float, float] default: None
+    position : Tuple[float, float] default: (0, 0))
         Position of the block.
-    size : Tuple[float, float] default: None
+    size : Tuple[float, float] default: (0, 0)
         Size of the block.
     start_position : Tuple[float, float], default: (450, 582)
         Start position of the branches relative to the block.
@@ -1480,7 +1485,7 @@ def add_when_block_branches(
 
 
 def add_diagram_equation_set(
-    diagram: suite.NetDiagram, name: str, elements: List[suite.Presentable] = None
+    diagram: suite.NetDiagram, name: str, elements: Optional[List[suite.Presentable]] = None
 ) -> suite.EquationSet:
     """
     Add a new equation set to a graphical diagram.
@@ -1491,7 +1496,7 @@ def add_diagram_equation_set(
         Input diagram.
     name : str
         Name of the equation set.
-    elements : List[suite.Presentable], default: None
+    elements : List[suite.Presentable] | None, default: None
         List of elements to add to the equation set.
 
     Returns

--- a/src/ansys/scade/apitools/create/declaration.py
+++ b/src/ansys/scade/apitools/create/declaration.py
@@ -288,7 +288,7 @@ def add_enumeration_values(
 
     enumeration = type_.definition
     _check_object(enumeration, 'add_enumeration_values', 'type_', suite.Enumeration)
-    assert isinstance(enumeration, suite.Enumeration)
+    assert isinstance(enumeration, suite.Enumeration)  # nosec B101  # addresses linter
 
     index = len(enumeration.values)  # default
     if insert_before is not None:

--- a/src/ansys/scade/apitools/create/expression.py
+++ b/src/ansys/scade/apitools/create/expression.py
@@ -92,7 +92,7 @@ EX = Union[bool, int, float, str, suite.ConstVar, suite.NamedType, ET]
 """Extended expression tree to simplify use of the create functions."""
 
 LX = Union[EX, Sequence[EX]]
-"""Extended collection of expression trees to simplify the use of create functions."""
+"""Extended sequence of expression trees to simplify the use of create functions."""
 
 
 class _Value(ET):

--- a/src/ansys/scade/apitools/create/expression.py
+++ b/src/ansys/scade/apitools/create/expression.py
@@ -54,6 +54,7 @@ Notes: The typing is relaxed in this module to ease the constructs.
 
 """
 
+from abc import ABC, abstractmethod
 from typing import List, Optional, Sequence, Tuple, Union
 
 import scade.model.suite as suite
@@ -64,17 +65,17 @@ from .scade import _add_pending_link
 
 
 # expression trees
-class ExpressionTree:
+class ExpressionTree(ABC):
     """Provides the top-level abstract class for expression trees."""
 
     def __init__(self, label: str = ''):
         """Any expression can have a label."""
         self.label = label
 
+    @abstractmethod
     def _build_expression(self, context: suite.Object) -> suite.Expression:
         """Build a SCADE Suite expression from the expression tree."""
-        # must be overridden
-        assert False  # pragma no cover
+        raise NotImplementedError  # pragma no cover
 
     def _set_label(self, expr: suite.Expression, context: suite.Object):
         """Add the label to the expression, if any."""
@@ -1359,7 +1360,6 @@ def _find_expr_id(expr: suite.Expression, index: int) -> Optional[suite.ExprId]:
         return None
 
     # expr is an ExprCall
-    assert isinstance(expr, suite.ExprCall)
     params = expr.parameters
     code = Eck(expr.predef_opr)
     if code == Eck.IF:

--- a/src/ansys/scade/apitools/create/expression.py
+++ b/src/ansys/scade/apitools/create/expression.py
@@ -454,14 +454,14 @@ def create_binary(
 
 
 def create_nary(op: str, *args: EX, modifiers: Union[ET, List[ET], None] = None) -> ET:
-    """
+    r"""
     Return the expression tree for a nary operator.
 
     Parameters
     ----------
     op : str
         Nary operator to call: & | | | ^ | # | + | *
-    *args : EX
+    \*args : EX
         Operands: expression trees.
     modifiers : Union[ET, List[ET], None], default: None
         List of higher-order constructs, to be provided as keyword parameter.
@@ -572,7 +572,7 @@ def create_make(
     ----------
     type\_ : suite.NamedType
         Type to instantiate.
-    *args : EX
+    \*args : EX
         Values of the type instance.
     modifiers : Union[ET, List[ET], None], default: None
         List of higher-order constructs, which is provided as a keyword parameter.
@@ -620,7 +620,7 @@ def create_flatten(
 
 
 def create_scalar_to_vector(size: EX, *args: EX) -> ET:
-    """
+    r"""
     Return the expression tree for the scalar-to-vector operator.
 
     Notes
@@ -632,7 +632,7 @@ def create_scalar_to_vector(size: EX, *args: EX) -> ET:
     ----------
     size: EX
         Size of the vector.
-    *args : EX
+    \*args : EX
         Input values.
 
     Returns
@@ -648,12 +648,12 @@ def create_scalar_to_vector(size: EX, *args: EX) -> ET:
 
 
 def create_data_array(*args: EX) -> ET:
-    """
+    r"""
     Return the expression tree for the data array operator.
 
     Parameters
     ----------
-    *args : EX
+    \*args : EX
         Values of the array.
 
     Returns
@@ -667,7 +667,7 @@ def create_data_array(*args: EX) -> ET:
 
 
 def create_data_struct(*args: Tuple[str, EX]) -> ET:
-    """
+    r"""
     Return the expression tree for the data strictire operator.
 
     Notes
@@ -677,7 +677,7 @@ def create_data_struct(*args: Tuple[str, EX]) -> ET:
 
     Parameters
     ----------
-    *args : Tuple[str, EX]
+    \*args : Tuple[str, EX]
         Label/values expression trees.
 
     Returns
@@ -769,12 +769,12 @@ def create_change_ith(flow: EX, path: LX, value: EX) -> ET:
 
 
 def create_pre(*args: EX) -> ET:
-    """
+    r"""
     Return the expression tree for the pre operator.
 
     Parameters
     ----------
-    *args : EX
+    \*args : EX
         Input flows.
 
     Returns
@@ -896,12 +896,12 @@ def create_slice(array: EX, start: EX, end: EX) -> ET:
 
 
 def create_concat(*args: EX) -> ET:
-    """
+    r"""
     Return the expression tree for the concat operator.
 
     Parameters
     ----------
-    *args : EX
+    \*args : EX
         Input arrays to concatenate.
 
     Returns

--- a/src/ansys/scade/apitools/create/expression.py
+++ b/src/ansys/scade/apitools/create/expression.py
@@ -54,7 +54,7 @@ Notes: The typing is relaxed in this module to ease the constructs.
 
 """
 
-from typing import List, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import scade.model.suite as suite
 
@@ -90,16 +90,16 @@ ET = ExpressionTree
 EX = Union[bool, int, float, str, suite.ConstVar, suite.NamedType, ET]
 """Extended expression tree to simplify use of the create functions."""
 
-LX = Union[EX, List[EX]]
-"""Extended lists of expression trees to simply the use of create functions."""
+LX = Union[EX, Sequence[EX]]
+"""Extended collection of expression trees to simplify the use of create functions."""
 
 
 class _Value(ET):
     """Provides a literal value."""
 
-    def __init__(self, value: str, kind: str, **kwargs):
+    def __init__(self, value: str, kind: str, label: str = ''):
         """Literal value."""
-        super().__init__(**kwargs)
+        super().__init__(label)
         self.value = value
         self.kind = kind
 
@@ -118,9 +118,9 @@ class _Value(ET):
 class _Reference(ET):
     """Provides a reference to a SCADE constant or variable."""
 
-    def __init__(self, reference: suite.ConstVar, **kwargs):
+    def __init__(self, reference: suite.ConstVar, label: str = ''):
         """Initialize a constant, sensor, or local variable."""
-        super().__init__(**kwargs)
+        super().__init__(label)
         self.reference = reference
 
     def _build_expression(self, context: suite.Object) -> suite.Expression:
@@ -134,9 +134,9 @@ class _Reference(ET):
 class _Type(ET):
     """Creates a reference to a type."""
 
-    def __init__(self, type_: suite.NamedType, **kwargs):
+    def __init__(self, type_: suite.NamedType, label: str = ''):
         """Initialize a named type."""
-        super().__init__(**kwargs)
+        super().__init__(label)
         self.type = type_
 
     def _build_expression(self, context: suite.Object) -> suite.Expression:
@@ -150,9 +150,14 @@ class _Call(ET):
     """Provides the base class for expression calls."""
 
     def __init__(
-        self, args: List[ET], inst_args: List[ET], modifiers: List[ET], name: str = '', **kwargs
+        self,
+        args: List[ET],
+        inst_args: List[ET],
+        modifiers: List[ET],
+        name: str = '',
+        label: str = '',
     ):
-        super().__init__(**kwargs)
+        super().__init__(label)
         self.args = args
         self.inst_args = inst_args
         self.modifiers = modifiers
@@ -177,8 +182,16 @@ class _Call(ET):
 class _Predefined(_Call):
     """Provides a calls to a predefined operator."""
 
-    def __init__(self, eck: Eck, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        eck: Eck,
+        args: List[ET],
+        inst_args: List[ET],
+        modifiers: List[ET],
+        name: str = '',
+        label: str = '',
+    ):
+        super().__init__(args, inst_args, modifiers, name, label)
         self.eck = eck
 
     def _build_expression(self, context: suite.Object) -> suite.Expression:
@@ -191,8 +204,16 @@ class _Predefined(_Call):
 class _Operator(_Call):
     """Provides a call to a user operator."""
 
-    def __init__(self, operator: suite.Operator, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        operator: suite.Operator,
+        args: List[ET],
+        inst_args: List[ET],
+        modifiers: List[ET],
+        name: str = '',
+        label: str = '',
+    ):
+        super().__init__(args, inst_args, modifiers, name, label)
         self.operator = operator
 
     def _build_expression(self, context: suite.Object) -> suite.Expression:
@@ -208,9 +229,10 @@ def _normalize_tree(any: EX) -> ET:
         return any
     # collections
     if isinstance(any, tuple) or isinstance(any, list):
+        # backward compatibility: use _normalize_trees instead for proper typing
         if len(any) == 0:
             raise EmptyTreeError()
-        return [_normalize_tree(_) for _ in any]
+        return [_normalize_tree(_) for _ in any]  # type: ignore
     # SCADE objects
     if isinstance(any, suite.ConstVar):
         return _Reference(any)
@@ -244,10 +266,17 @@ def _normalize_tree(any: EX) -> ET:
     raise ExprSyntaxError('_normalize_tree', any)
 
 
+def _normalize_trees(any: Sequence[EX]) -> List[ET]:
+    """Normalize a collection of expression trees."""
+    if len(any) == 0:
+        raise EmptyTreeError()
+    return [_normalize_tree(_) for _ in any]
+
+
 def _normalize_tree_ex(any: LX) -> List[ET]:
     """Normalize a collection of expression trees or a single one."""
     if isinstance(any, list):
-        return _normalize_tree(any)
+        return _normalize_trees(any)
     else:
         return [_normalize_tree(any)]
 
@@ -267,10 +296,11 @@ def _build_expression(tree: EX, context: suite.Object) -> suite.Expression:
     -------
     suite.Expression
     """
+    # backward compatibility: allow None expressions
     if tree is None:
         return None
-    tree = _normalize_tree(tree)
-    return tree._build_expression(context)
+    norm_tree = _normalize_tree(tree)
+    return norm_tree._build_expression(context)
 
 
 # association tables
@@ -308,7 +338,7 @@ _binary_ops = {
 _nary_ops = {'&': Eck.AND, '|': Eck.OR, '^': Eck.XOR, '#': Eck.SHARP, '+': Eck.PLUS, '*': Eck.MUL}
 
 
-def create_call(operator: suite.Operator, args: LX, inst_args: LX = None) -> ET:
+def create_call(operator: suite.Operator, args: LX, inst_args: Optional[LX] = None) -> ET:
     """
     Return the expression tree for a call to an operator.
 
@@ -318,7 +348,7 @@ def create_call(operator: suite.Operator, args: LX, inst_args: LX = None) -> ET:
         Operator to call.
     args : Union[EX, List[EX]]
         Parameters: expression trees.
-    inst_args : Union[EX, List[EX]]
+    inst_args : Union[EX, List[EX], None], default: None
         Instance parameters: expression trees.
 
     Returns
@@ -328,13 +358,16 @@ def create_call(operator: suite.Operator, args: LX, inst_args: LX = None) -> ET:
     if inst_args is None:
         inst_args = []
     _check_object(operator, 'create_call', 'operator', suite.Operator)
-    args = _normalize_tree_ex(args) if args else []
-    inst_args = _normalize_tree_ex(inst_args) if inst_args else []
-    return _Operator(operator, args, inst_args, [])
+    norm_args = _normalize_tree_ex(args) if args else []
+    norm_inst_args = _normalize_tree_ex(inst_args) if inst_args else []
+    return _Operator(operator, norm_args, norm_inst_args, [])
 
 
 def create_higher_order_call(
-    operator: suite.Operator, args: LX, modifiers: Union[ET, List[ET]], inst_args: LX = None
+    operator: suite.Operator,
+    args: LX,
+    modifiers: Union[ET, List[ET]],
+    inst_args: Optional[LX] = None,
 ) -> ET:
     """
     Return the expression tree for a call to an operator.
@@ -347,7 +380,7 @@ def create_higher_order_call(
         Parameters: expression trees.
     modifiers : Union[ET, List[ET]]
         Higher-order constructs: expression trees.
-    inst_args : Union[EX, List[EX]]
+    inst_args : Union[EX, List[EX], None], default: None
         Instance parameters: expression trees.
 
     Returns
@@ -357,16 +390,16 @@ def create_higher_order_call(
     if inst_args is None:
         inst_args = []
     _check_object(operator, 'create_higher_order_call', 'operator', suite.Operator)
-    args = _normalize_tree_ex(args) if args else []
-    inst_args = _normalize_tree_ex(inst_args) if inst_args else []
+    norm_args = _normalize_tree_ex(args) if args else []
+    norm_inst_args = _normalize_tree_ex(inst_args) if inst_args else []
     modifiers = modifiers if isinstance(modifiers, list) else [modifiers] if modifiers else []
-    return _Operator(operator, args, inst_args, modifiers)
+    return _Operator(operator, norm_args, norm_inst_args, modifiers)
 
 
 # arithmetic and logic
 
 
-def create_unary(op: str, tree: EX, modifiers: Union[ET, List[ET]] = None) -> ET:
+def create_unary(op: str, tree: EX, modifiers: Union[ET, List[ET], None] = None) -> ET:
     """
     Return the expression tree for a unary operator.
 
@@ -376,7 +409,7 @@ def create_unary(op: str, tree: EX, modifiers: Union[ET, List[ET]] = None) -> ET
         Unary operator to call: - | + | !
     tree : EX
         Operand: expression tree.
-    modifiers : Union[ET, LIST[ET]], default: None
+    modifiers : Union[ET, LIST[ET], None], default: None
         List of higher-order constructs.
 
     Returns
@@ -386,12 +419,14 @@ def create_unary(op: str, tree: EX, modifiers: Union[ET, List[ET]] = None) -> ET
     eck = _unary_ops.get(op)
     if eck is None:
         raise ExprSyntaxError('create_unary', op)
-    tree = _normalize_tree(tree)
+    norm_tree = _normalize_tree(tree)
     modifiers = modifiers if isinstance(modifiers, list) else [modifiers] if modifiers else []
-    return _Predefined(eck, [tree], [], modifiers)
+    return _Predefined(eck, [norm_tree], [], modifiers)
 
 
-def create_binary(op: str, tree1: EX, tree2: EX, modifiers: Union[ET, List[ET]] = None) -> ET:
+def create_binary(
+    op: str, tree1: EX, tree2: EX, modifiers: Union[ET, List[ET], None] = None
+) -> ET:
     """
     Return the expression tree for a binary operator.
 
@@ -403,7 +438,7 @@ def create_binary(op: str, tree1: EX, tree2: EX, modifiers: Union[ET, List[ET]] 
         First operand: expression tree.
     tree2 : EX
         Second operand: expression tree.
-    modifiers : Union[ET, List[ET]], default: None
+    modifiers : Union[ET, List[ET], None], default: None
         List of higher-order constructs.
 
     Returns
@@ -413,12 +448,12 @@ def create_binary(op: str, tree1: EX, tree2: EX, modifiers: Union[ET, List[ET]] 
     eck = _binary_ops.get(op)
     if eck is None:
         raise ExprSyntaxError('create_binary', op)
-    tree1, tree2 = _normalize_tree((tree1, tree2))
+    norm_tree1, norm_tree2 = _normalize_trees((tree1, tree2))
     modifiers = modifiers if isinstance(modifiers, list) else [modifiers] if modifiers else []
-    return _Predefined(eck, [tree1, tree2], [], modifiers)
+    return _Predefined(eck, [norm_tree1, norm_tree2], [], modifiers)
 
 
-def create_nary(op: str, *args: List[EX], modifiers: Union[ET, List[ET]] = None) -> ET:
+def create_nary(op: str, *args: EX, modifiers: Union[ET, List[ET], None] = None) -> ET:
     """
     Return the expression tree for a nary operator.
 
@@ -426,9 +461,9 @@ def create_nary(op: str, *args: List[EX], modifiers: Union[ET, List[ET]] = None)
     ----------
     op : str
         Nary operator to call: & | | | ^ | # | + | *
-    args : List[EX]
+    *args : EX
         Operands: expression trees.
-    modifiers : Union[ET, List[ET]], default: None
+    modifiers : Union[ET, List[ET], None], default: None
         List of higher-order constructs, to be provided as keyword parameter.
 
     Returns
@@ -440,9 +475,9 @@ def create_nary(op: str, *args: List[EX], modifiers: Union[ET, List[ET]] = None)
         raise ExprSyntaxError('create_nary', op)
     if len(args) < 2:
         raise ExprSyntaxError('create_nary', args)
-    args = _normalize_tree(args)
+    norm_args = _normalize_trees(args)
     modifiers = modifiers if isinstance(modifiers, list) else [modifiers] if modifiers else []
-    return _Predefined(eck, args, [], modifiers)
+    return _Predefined(eck, norm_args, [], modifiers)
 
 
 # selectors
@@ -476,14 +511,14 @@ def create_if(condition: EX, then: LX, else_: LX) -> ET:
     if length == 0 or length != len(norm_else):
         raise ExprSyntaxError('create_if', then)
 
-    condition = _normalize_tree(condition)
+    norm_condition = _normalize_tree(condition)
     then_tree = _create_sequence(norm_then)
     else_tree = _create_sequence(norm_else)
 
-    return _Predefined(Eck.IF, [condition, then_tree, else_tree], [], [])
+    return _Predefined(Eck.IF, [norm_condition, then_tree, else_tree], [], [])
 
 
-def create_case(selector: EX, cases: List[Tuple[EX, EX]], default: EX = None) -> ET:
+def create_case(selector: EX, cases: List[Tuple[EX, EX]], default: Optional[EX] = None) -> ET:
     """
     Return the expression tree for the case operator.
 
@@ -499,7 +534,7 @@ def create_case(selector: EX, cases: List[Tuple[EX, EX]], default: EX = None) ->
         Expression tree corresponding to the selector.
     cases : List[Tuple[EX, EX]]
         Pattern/values expression trees.
-    default: EX, default:None
+    default: EX | None, default:None
         Default value.
 
     Returns
@@ -509,7 +544,7 @@ def create_case(selector: EX, cases: List[Tuple[EX, EX]], default: EX = None) ->
     if len(cases) == 0:
         raise ExprSyntaxError('create_case', cases)
 
-    selector = _normalize_tree(selector)
+    norm_selector = _normalize_tree(selector)
     patterns = []
     inputs = []
     for pattern, input in cases:
@@ -521,14 +556,14 @@ def create_case(selector: EX, cases: List[Tuple[EX, EX]], default: EX = None) ->
     pattern_tree = _create_sequence(patterns)
     input_tree = _create_sequence(inputs)
 
-    return _Predefined(Eck.CASE, [selector, input_tree, pattern_tree], [], [])
+    return _Predefined(Eck.CASE, [norm_selector, input_tree, pattern_tree], [], [])
 
 
 # types
 
 
 def create_make(
-    type_: suite.NamedType, *args: List[EX], modifiers: Union[ET, List[ET]] = None
+    type_: suite.NamedType, *args: EX, modifiers: Union[ET, List[ET], None] = None
 ) -> ET:
     r"""
     Return the expression tree for making a structured value.
@@ -537,9 +572,9 @@ def create_make(
     ----------
     type\_ : suite.NamedType
         Type to instantiate.
-    args : List[EX]
+    *args : EX
         Values of the type instance.
-    modifiers : Union[ET, List[ET]], default: None
+    modifiers : Union[ET, List[ET], None], default: None
         List of higher-order constructs, which is provided as a keyword parameter.
 
     Returns
@@ -549,12 +584,15 @@ def create_make(
     if len(args) < 1:
         raise ExprSyntaxError('create_make', args)
     _check_object(type_, 'create_make', 'type', suite.NamedType)
-    args, type_ = _normalize_tree((args, type_))
+    norm_type = _normalize_tree(type_)
+    norm_args = _normalize_trees(args)
     modifiers = modifiers if isinstance(modifiers, list) else [modifiers] if modifiers else []
-    return _Predefined(Eck.MAKE, [_create_sequence(args), type_], [], modifiers)
+    return _Predefined(Eck.MAKE, [_create_sequence(norm_args), norm_type], [], modifiers)
 
 
-def create_flatten(type_: suite.NamedType, arg: EX, modifiers: Union[ET, List[ET]] = None) -> ET:
+def create_flatten(
+    type_: suite.NamedType, arg: EX, modifiers: Union[ET, List[ET], None] = None
+) -> ET:
     r"""
     Return the expression tree for flattening a structured value.
 
@@ -564,7 +602,7 @@ def create_flatten(type_: suite.NamedType, arg: EX, modifiers: Union[ET, List[ET
         Type to instantiate.
     arg : EX
         Value to flatten.
-    modifiers : Union[ET, List[ET]], default: None
+    modifiers : Union[ET, List[ET], None], default: None
         List of higher-order constructs.
 
     Returns
@@ -572,15 +610,16 @@ def create_flatten(type_: suite.NamedType, arg: EX, modifiers: Union[ET, List[ET
     ET
     """
     _check_object(type_, 'create_flatten', 'type', suite.NamedType)
-    arg, type_ = _normalize_tree((arg, type_))
+    norm_type = _normalize_tree(type_)
+    norm_arg = _normalize_tree(arg)
     modifiers = modifiers if isinstance(modifiers, list) else [modifiers] if modifiers else []
-    return _Predefined(Eck.FLATTEN, [arg, type_], [], modifiers)
+    return _Predefined(Eck.FLATTEN, [norm_arg, norm_type], [], modifiers)
 
 
 # structures
 
 
-def create_scalar_to_vector(size: EX, *args: List[EX]) -> ET:
+def create_scalar_to_vector(size: EX, *args: EX) -> ET:
     """
     Return the expression tree for the scalar-to-vector operator.
 
@@ -593,7 +632,7 @@ def create_scalar_to_vector(size: EX, *args: List[EX]) -> ET:
     ----------
     size: EX
         Size of the vector.
-    args : List[EX]
+    *args : EX
         Input values.
 
     Returns
@@ -602,19 +641,19 @@ def create_scalar_to_vector(size: EX, *args: List[EX]) -> ET:
     """
     if len(args) == 0:
         raise ExprSyntaxError('create_scalar_to_vector', args)
-    size = _normalize_tree(size)
-    args = _normalize_tree(args)
+    norm_size = _normalize_tree(size)
+    norm_args = _normalize_trees(args)
     # the size must be the last parameter
-    return _Predefined(Eck.SCALAR_TO_VECTOR, list(args) + [size], [], [])
+    return _Predefined(Eck.SCALAR_TO_VECTOR, norm_args + [norm_size], [], [])
 
 
-def create_data_array(*args: List[EX]) -> ET:
+def create_data_array(*args: EX) -> ET:
     """
     Return the expression tree for the data array operator.
 
     Parameters
     ----------
-    args : List[EX]
+    *args : EX
         Values of the array.
 
     Returns
@@ -623,11 +662,11 @@ def create_data_array(*args: List[EX]) -> ET:
     """
     if len(args) == 0:
         raise ExprSyntaxError('create_data_array', args)
-    args = _normalize_tree(args)
-    return _Predefined(Eck.BLD_VECTOR, args, [], [])
+    norm_args = _normalize_trees(args)
+    return _Predefined(Eck.BLD_VECTOR, norm_args, [], [])
 
 
-def create_data_struct(*args: List[Tuple[str, EX]]) -> ET:
+def create_data_struct(*args: Tuple[str, EX]) -> ET:
     """
     Return the expression tree for the data strictire operator.
 
@@ -638,7 +677,7 @@ def create_data_struct(*args: List[Tuple[str, EX]]) -> ET:
 
     Parameters
     ----------
-    args : List[Tuple[str, EX]]
+    *args : Tuple[str, EX]
         Label/values expression trees.
 
     Returns
@@ -674,9 +713,9 @@ def create_prj(flow: EX, path: LX) -> ET:
     -------
     ET
     """
-    flow = _normalize_tree(flow)
-    path = _normalize_tree_ex(path)
-    parameters = [flow] + path
+    norm_flow = _normalize_tree(flow)
+    norm_path = _normalize_tree_ex(path)
+    parameters = [norm_flow] + norm_path
     return _Predefined(Eck.PRJ, parameters, [], [])
 
 
@@ -697,9 +736,9 @@ def create_prj_dyn(flow: EX, path: LX, default: EX) -> ET:
     -------
     ET
     """
-    flow, default = _normalize_tree((flow, default))
-    path = _normalize_tree_ex(path)
-    parameters = [flow] + path + [default]
+    norm_flow, norm_default = _normalize_trees((flow, default))
+    norm_path = _normalize_tree_ex(path)
+    parameters = [norm_flow] + norm_path + [norm_default]
     return _Predefined(Eck.PRJ_DYN, parameters, [], [])
 
 
@@ -720,22 +759,22 @@ def create_change_ith(flow: EX, path: LX, value: EX) -> ET:
     -------
     ET
     """
-    flow, value = _normalize_tree((flow, value))
-    path = _normalize_tree_ex(path)
-    parameters = [flow, value] + path
+    norm_flow, norm_value = _normalize_trees((flow, value))
+    norm_path = _normalize_tree_ex(path)
+    parameters = [norm_flow, norm_value] + norm_path
     return _Predefined(Eck.CHANGE_ITH, parameters, [], [])
 
 
 # time
 
 
-def create_pre(*args: List[EX]) -> ET:
+def create_pre(*args: EX) -> ET:
     """
     Return the expression tree for the pre operator.
 
     Parameters
     ----------
-    args : List[EX]
+    *args : EX
         Input flows.
 
     Returns
@@ -744,8 +783,8 @@ def create_pre(*args: List[EX]) -> ET:
     """
     if len(args) == 0:
         raise ExprSyntaxError('create_pre', '')
-    args = _normalize_tree(args)
-    return _Predefined(Eck.PRE, args, [], [])
+    norm_args = _normalize_trees(args)
+    return _Predefined(Eck.PRE, norm_args, [], [])
 
 
 def create_init(flows: LX, inits: LX) -> ET:
@@ -808,8 +847,8 @@ def create_fby(flows: LX, delay: EX, inits: LX) -> ET:
     if length == 0 or length != len(norm_inits):
         raise ExprSyntaxError('create_fby', flows)
 
-    delay = _normalize_tree(delay)
-    parameters = norm_flows + [delay] + norm_inits
+    norm_delay = _normalize_tree(delay)
+    parameters = norm_flows + [norm_delay] + norm_inits
     return _Predefined(Eck.FBY, parameters, [], [])
 
 
@@ -828,8 +867,8 @@ def create_times(number: EX, flow: EX) -> ET:
     -------
     ET
     """
-    number, flow = _normalize_tree((number, flow))
-    return _Predefined(Eck.TIMES, [number, flow], [], [])
+    norm_number, norm_flow = _normalize_trees((number, flow))
+    return _Predefined(Eck.TIMES, [norm_number, norm_flow], [], [])
 
 
 # array
@@ -852,17 +891,17 @@ def create_slice(array: EX, start: EX, end: EX) -> ET:
     -------
     ET
     """
-    array, start, end = _normalize_tree((array, start, end))
-    return _Predefined(Eck.SLICE, [array, start, end], [], [])
+    norm_array, norm_start, norm_end = _normalize_trees((array, start, end))
+    return _Predefined(Eck.SLICE, [norm_array, norm_start, norm_end], [], [])
 
 
-def create_concat(*args: List[EX]) -> ET:
+def create_concat(*args: EX) -> ET:
     """
     Return the expression tree for the concat operator.
 
     Parameters
     ----------
-    args : List[EX]
+    *args : EX
         Input arrays to concatenate.
 
     Returns
@@ -871,8 +910,8 @@ def create_concat(*args: List[EX]) -> ET:
     """
     if len(args) < 2:
         raise ExprSyntaxError('create_concat', args)
-    args = _normalize_tree(args)
-    return _Predefined(Eck.CONCAT, args, [], [])
+    norm_args = _normalize_trees(args)
+    return _Predefined(Eck.CONCAT, norm_args, [], [])
 
 
 def create_reverse(flow: EX) -> ET:
@@ -888,8 +927,8 @@ def create_reverse(flow: EX) -> ET:
     -------
     ET
     """
-    flow = _normalize_tree(flow)
-    return _Predefined(Eck.REVERSE, [flow], [], [])
+    norm_flow = _normalize_tree(flow)
+    return _Predefined(Eck.REVERSE, [norm_flow], [], [])
 
 
 def create_transpose(array: EX, dim1: EX, dim2: EX) -> ET:
@@ -909,8 +948,8 @@ def create_transpose(array: EX, dim1: EX, dim2: EX) -> ET:
     -------
     ET
     """
-    array, dim1, dim2 = _normalize_tree((array, dim1, dim2))
-    return _Predefined(Eck.TRANSPOSE, [array, dim1, dim2], [], [])
+    norm_array, norm_dim1, norm_dim2 = _normalize_trees((array, dim1, dim2))
+    return _Predefined(Eck.TRANSPOSE, [norm_array, norm_dim1, norm_dim2], [], [])
 
 
 # activation
@@ -929,11 +968,11 @@ def create_restart(every: EX) -> ET:
     -------
     ET
     """
-    every = _normalize_tree(every)
-    return _Predefined(Eck.RESTART, [every], [], [])
+    norm_every = _normalize_tree(every)
+    return _Predefined(Eck.RESTART, [norm_every], [], [])
 
 
-def create_activate(every: EX, *args: List[EX]) -> ET:
+def create_activate(every: EX, *args: EX) -> ET:
     """
     Return the expression tree for the higher-order construct for activating with initial values.
 
@@ -941,20 +980,20 @@ def create_activate(every: EX, *args: List[EX]) -> ET:
     ----------
     every : EX
         Input condition.
-    args: List[EX]
+    *args: EX
         Initial values.
 
     Returns
     -------
     ET
     """
-    every = _normalize_tree(every)
+    norm_every = _normalize_tree(every)
     # args may be empty
-    args = _normalize_tree(args) if args else args
-    return _Predefined(Eck.ACTIVATE, [every, _create_sequence(args)], [], [])
+    norm_args = _normalize_trees(args) if args else []
+    return _Predefined(Eck.ACTIVATE, [norm_every, _create_sequence(norm_args)], [], [])
 
 
-def create_activate_no_init(every: EX, *args: List[EX]) -> ET:
+def create_activate_no_init(every: EX, *args: EX) -> ET:
     """
     Return the expression tree for the higher-order construct for activating with default values.
 
@@ -962,17 +1001,17 @@ def create_activate_no_init(every: EX, *args: List[EX]) -> ET:
     ----------
     every : EX
         Input condition.
-    args: List[EX]
+    *args: EX
         Default values.
 
     Returns
     -------
     ET
     """
-    every = _normalize_tree(every)
+    norm_every = _normalize_tree(every)
     # args may be empty
-    args = _normalize_tree(args) if args else args
-    return _Predefined(Eck.ACTIVATE_NOINIT, [every, _create_sequence(args)], [], [])
+    norm_args = _normalize_trees(args) if args else []
+    return _Predefined(Eck.ACTIVATE_NOINIT, [norm_every, _create_sequence(norm_args)], [], [])
 
 
 # iterators
@@ -991,8 +1030,8 @@ def create_map(size: EX) -> ET:
     -------
     ET
     """
-    size = _normalize_tree(size)
-    return _Predefined(Eck.MAP, [size], [], [])
+    norm_size = _normalize_tree(size)
+    return _Predefined(Eck.MAP, [norm_size], [], [])
 
 
 def create_mapi(size: EX) -> ET:
@@ -1008,8 +1047,8 @@ def create_mapi(size: EX) -> ET:
     -------
     ET
     """
-    size = _normalize_tree(size)
-    return _Predefined(Eck.MAPI, [size], [], [])
+    norm_size = _normalize_tree(size)
+    return _Predefined(Eck.MAPI, [norm_size], [], [])
 
 
 def create_fold(size: EX) -> ET:
@@ -1025,8 +1064,8 @@ def create_fold(size: EX) -> ET:
     -------
     ET
     """
-    size = _normalize_tree(size)
-    return _Predefined(Eck.FOLD, [size], [], [])
+    norm_size = _normalize_tree(size)
+    return _Predefined(Eck.FOLD, [norm_size], [], [])
 
 
 def create_foldi(size: EX) -> ET:
@@ -1042,8 +1081,8 @@ def create_foldi(size: EX) -> ET:
     -------
     ET
     """
-    size = _normalize_tree(size)
-    return _Predefined(Eck.FOLDI, [size], [], [])
+    norm_size = _normalize_tree(size)
+    return _Predefined(Eck.FOLDI, [norm_size], [], [])
 
 
 def create_mapfold(size: EX, acc: EX) -> ET:
@@ -1061,8 +1100,8 @@ def create_mapfold(size: EX, acc: EX) -> ET:
     -------
     ET
     """
-    size, acc = _normalize_tree((size, acc))
-    return _Predefined(Eck.MAPFOLD, [size, acc], [], [])
+    norm_size, norm_acc = _normalize_trees((size, acc))
+    return _Predefined(Eck.MAPFOLD, [norm_size, norm_acc], [], [])
 
 
 def create_mapfoldi(size: EX, acc: EX) -> ET:
@@ -1081,8 +1120,8 @@ def create_mapfoldi(size: EX, acc: EX) -> ET:
     -------
     ET
     """
-    size, acc = _normalize_tree((size, acc))
-    return _Predefined(Eck.MAPFOLDI, [size, acc], [], [])
+    norm_size, norm_acc = _normalize_trees((size, acc))
+    return _Predefined(Eck.MAPFOLDI, [norm_size, norm_acc], [], [])
 
 
 def create_foldw(size: EX, condition: EX) -> ET:
@@ -1100,8 +1139,8 @@ def create_foldw(size: EX, condition: EX) -> ET:
     -------
     ET
     """
-    size, condition = _normalize_tree((size, condition))
-    return _Predefined(Eck.FOLDW, [size, condition], [], [])
+    norm_size, norm_condition = _normalize_trees((size, condition))
+    return _Predefined(Eck.FOLDW, [norm_size, norm_condition], [], [])
 
 
 def create_foldwi(size: EX, condition: EX) -> ET:
@@ -1119,8 +1158,8 @@ def create_foldwi(size: EX, condition: EX) -> ET:
     -------
     ET
     """
-    size, condition = _normalize_tree((size, condition))
-    return _Predefined(Eck.FOLDWI, [size, condition], [], [])
+    norm_size, norm_condition = _normalize_trees((size, condition))
+    return _Predefined(Eck.FOLDWI, [norm_size, norm_condition], [], [])
 
 
 def create_mapw(size: EX, condition: EX, default: EX) -> ET:
@@ -1140,8 +1179,8 @@ def create_mapw(size: EX, condition: EX, default: EX) -> ET:
     -------
     ET
     """
-    size, condition, default = _normalize_tree((size, condition, default))
-    return _Predefined(Eck.MAPW, [size, condition, default], [], [])
+    norm_size, norm_condition, norm_default = _normalize_trees((size, condition, default))
+    return _Predefined(Eck.MAPW, [norm_size, norm_condition, norm_default], [], [])
 
 
 def create_mapwi(size: EX, condition: EX, default: EX) -> ET:
@@ -1161,8 +1200,8 @@ def create_mapwi(size: EX, condition: EX, default: EX) -> ET:
     -------
     ET
     """
-    size, condition, default = _normalize_tree((size, condition, default))
-    return _Predefined(Eck.MAPWI, [size, condition, default], [], [])
+    norm_size, norm_condition, norm_default = _normalize_trees((size, condition, default))
+    return _Predefined(Eck.MAPWI, [norm_size, norm_condition, norm_default], [], [])
 
 
 def create_mapfoldw(size: EX, acc: EX, condition: EX, default: EX) -> ET:
@@ -1184,8 +1223,10 @@ def create_mapfoldw(size: EX, acc: EX, condition: EX, default: EX) -> ET:
     -------
     ET
     """
-    size, acc, condition, default = _normalize_tree((size, acc, condition, default))
-    return _Predefined(Eck.MAPFOLDW, [size, acc, condition, default], [], [])
+    norm_size, norm_acc, norm_condition, norm_default = _normalize_trees(
+        (size, acc, condition, default)
+    )
+    return _Predefined(Eck.MAPFOLDW, [norm_size, norm_acc, norm_condition, norm_default], [], [])
 
 
 def create_mapfoldwi(size: EX, acc: EX, condition: EX, default: EX) -> ET:
@@ -1207,15 +1248,17 @@ def create_mapfoldwi(size: EX, acc: EX, condition: EX, default: EX) -> ET:
     -------
     ET
     """
-    size, acc, condition, default = _normalize_tree((size, acc, condition, default))
-    return _Predefined(Eck.MAPFOLDWI, [size, acc, condition, default], [], [])
+    norm_size, norm_acc, norm_condition, norm_default = _normalize_trees(
+        (size, acc, condition, default)
+    )
+    return _Predefined(Eck.MAPFOLDWI, [norm_size, norm_acc, norm_condition, norm_default], [], [])
 
 
 # ----------------------------------------------------------------------------
 # Helpers (private)
 
 
-def _create_sequence(flows: List[EX]) -> ET:
+def _create_sequence(flows: List[ET]) -> ET:
     """Create an expression tree for a group of flows."""
     return _Predefined(Eck.SEQ_EXPR, flows, [], [])
 
@@ -1287,7 +1330,7 @@ def _is_bool(value: str) -> bool:
 
 # TODO: modifiers
 # TODO: move to query
-def _find_expr_id(expr: suite.Expression, index: int) -> suite.ExprId:
+def _find_expr_id(expr: suite.Expression, index: int) -> Optional[suite.ExprId]:
     """
     Return the ``ExprId`` instance corresponding to the pin index of an equation.
 
@@ -1316,6 +1359,7 @@ def _find_expr_id(expr: suite.Expression, index: int) -> suite.ExprId:
         return None
 
     # expr is an ExprCall
+    assert isinstance(expr, suite.ExprCall)
     params = expr.parameters
     code = Eck(expr.predef_opr)
     if code == Eck.IF:

--- a/src/ansys/scade/apitools/create/expression.py
+++ b/src/ansys/scade/apitools/create/expression.py
@@ -974,14 +974,14 @@ def create_restart(every: EX) -> ET:
 
 
 def create_activate(every: EX, *args: EX) -> ET:
-    """
+    r"""
     Return the expression tree for the higher-order construct for activating with initial values.
 
     Parameters
     ----------
     every : EX
         Input condition.
-    *args: EX
+    \*args: EX
         Initial values.
 
     Returns
@@ -995,14 +995,14 @@ def create_activate(every: EX, *args: EX) -> ET:
 
 
 def create_activate_no_init(every: EX, *args: EX) -> ET:
-    """
+    r"""
     Return the expression tree for the higher-order construct for activating with default values.
 
     Parameters
     ----------
     every : EX
         Input condition.
-    *args: EX
+    \*args: EX
         Default values.
 
     Returns

--- a/src/ansys/scade/apitools/create/project.py
+++ b/src/ansys/scade/apitools/create/project.py
@@ -27,7 +27,7 @@ These functions do not check for semantic errors, like adding two files with the
 """
 
 from os.path import abspath
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import scade.model.project.stdproject as std
 
@@ -146,7 +146,7 @@ def create_configuration(owner: std.Project, name: str) -> std.Configuration:
 
 
 def create_prop(
-    owner: std.Annotable, configuration: std.Configuration, name: str, values: List[str]
+    owner: std.Annotable, configuration: Optional[std.Configuration], name: str, values: List[str]
 ) -> std.Prop:
     """
     Create a property.
@@ -159,7 +159,7 @@ def create_prop(
     ----------
     owner : std.Annotable
         Element to attach the property to.
-    configuration : str
+    configuration : Configuration | None
         Configuration to associate with the property or ``None``.
     name : str
         Name of the property.
@@ -207,7 +207,7 @@ def save_project(project: std.Project):
 
 
 # not sure this is a good idea... keep this function for tests only?
-def _create_empty_project(pathname: str, configuration: str, products: List[str] = None):
+def _create_empty_project(pathname: str, configuration: str, products: Optional[List[str]] = None):
     """
     Create the smallest project file as possible on the disk.
 
@@ -221,7 +221,7 @@ def _create_empty_project(pathname: str, configuration: str, products: List[str]
         Path of the project.
     configuration : str
         Name of the configuration. A project must have at least one configuration.
-    products: List[str], default: None
+    products: List[str] | None, default: None
         List of tags identifying the nature of the project.
         For example, ``SC`` indicates a SCADE Suite project.
     """
@@ -283,7 +283,7 @@ def _create_empty_project(pathname: str, configuration: str, products: List[str]
 #         return self.context + ': ' + self.name + ': Illegal class ' + str(self.cls)
 
 
-def _check_object(object_, context: str, name: str, classes: Tuple[Any, ...]):
+def _check_object(object_, context: str, name: str, classes: Union[Any, Tuple[Any, ...]]):
     """Check the type of a parameter and raise a ``TypeError`` if it is not correct."""
     if not isinstance(object_, classes):
         cls = type(object_).__name__
@@ -297,7 +297,7 @@ def _check_object(object_, context: str, name: str, classes: Tuple[Any, ...]):
 
 
 # to be moved to query.project
-def _find_file_ref(project: std.Project, pathname: str) -> std.FileRef:
+def _find_file_ref(project: std.Project, pathname: str) -> Optional[std.FileRef]:
     """
     Search a project for a file with the provided path.
 

--- a/src/ansys/scade/apitools/create/project.py
+++ b/src/ansys/scade/apitools/create/project.py
@@ -76,7 +76,7 @@ def create_folder(
         folder = std.Folder(owner)
         folder.owner = owner
     else:
-        assert isinstance(owner, std.Folder)
+        # assert isinstance(owner, std.Folder)
         folder = std.Folder(owner.project)
         folder.folder = owner
 
@@ -110,7 +110,7 @@ def create_file_ref(owner: Union[std.Project, std.Folder], persist_as: str) -> s
         file_ref = std.FileRef(owner)
         file_ref.owner = owner
     else:
-        assert isinstance(owner, std.Folder)
+        # assert isinstance(owner, std.Folder)
         file_ref = std.FileRef(owner.project)
         file_ref.folder = owner
 

--- a/src/ansys/scade/apitools/create/scade.py
+++ b/src/ansys/scade/apitools/create/scade.py
@@ -31,7 +31,7 @@ Provides helpers for SCADE model creation functions.
 from enum import Enum
 from os.path import abspath, relpath
 from pathlib import Path
-from typing import Union
+from typing import List, Optional, Union
 
 import scade.model.project.stdproject as std
 import scade.model.suite as suite
@@ -82,7 +82,7 @@ def save_all():
 def add_element_to_project(
     project: std.Project,
     element: suite.StorageElement,
-    folder: std.Folder = None,
+    folder: Optional[std.Folder] = None,
     default: bool = True,
 ) -> std.FileRef:
     """
@@ -107,7 +107,7 @@ def add_element_to_project(
         Element with storage unit to add to the project.
         If the storage unit is not a root element, the added file is
         tagged as ``NONROOT`` for SCADE.
-    folder : std.Folder, default: None
+    folder : std.Folder | None, default: None
         Parent folder of the file to add to the project.
     default : bool, default: True
         Whether to add the file to one of the default folders
@@ -119,7 +119,7 @@ def add_element_to_project(
     """
     unit = element.defined_in
     path = unit.sao_file_name
-    file_ref = _find_file_ref(project, Path(path))
+    file_ref = _find_file_ref(project, path)
     if not file_ref:
         if folder:
             parent = folder
@@ -142,7 +142,7 @@ def add_imported_to_project(
     project: std.Project,
     element: Union[suite.NamedType, suite.Operator],
     path: str,
-    folder: std.Folder = None,
+    folder: Optional[std.Folder] = None,
     default: bool = True,
 ) -> std.FileRef:
     """
@@ -166,8 +166,8 @@ def add_imported_to_project(
         Imported element.
     path : str
         Path of the file to add to the project.
-    folder : std.Folder
-        Parent folder of the file to add to the project.
+    folder : std.Folder | None
+        Parent folder of the file to add to the project, default: None.
     default : bool, default: True
         Whether to add the file is added to the default folder
         for SCADE Simulation files, according to the element.
@@ -195,7 +195,7 @@ def add_imported_to_project(
 
 
 def add_simulation_file_to_project(
-    project: std.Project, path: str, kind: Sfk, folder: std.Folder = None, default=True
+    project: std.Project, path: str, kind: Sfk, folder: Optional[std.Folder] = None, default=True
 ) -> std.FileRef:
     """
     Add a file to the project and tag it appropriately for the SCADE simulation.
@@ -218,7 +218,7 @@ def add_simulation_file_to_project(
         Path of the file to be added to the project.
     kind: Sfk
         Kind of the added file.
-    folder : std.Folder
+    folder : std.Folder | None, default: None
         Parent folder of the file to add to the project.
     default : bool
         When True, the file is added to the default folder
@@ -309,7 +309,8 @@ def _get_model_project(model: suite.Model) -> std.Project:
     std.Project
     """
     pathname = abspath(model.descriptor.model_file_name)
-    return next((_ for _ in std.get_roots() if abspath(_.pathname) == pathname), None)
+    projects: List[std.Project] = std.get_roots()
+    return next((_ for _ in projects if abspath(_.pathname) == pathname), None)
 
 
 def _get_default_file(model: suite.Model) -> Path:
@@ -343,7 +344,11 @@ def _get_default_file(model: suite.Model) -> Path:
     return path
 
 
-def _link_storage_element(owner: suite.Package, element: suite.StorageElement, path: Path):
+def _link_storage_element(
+    owner: suite.Package,
+    element: suite.StorageElement,
+    path: Optional[Path] = None,
+):
     """
     Link a storage element to the storage unit specified by a path.
 
@@ -361,7 +366,7 @@ def _link_storage_element(owner: suite.Package, element: suite.StorageElement, p
         Owner of the storage element.
     element : suite.StorageELement
         Element to add to the storage unit.
-    path : Path
+    path : Path | None, default: None
         Path of the storage unit.
 
     Returns
@@ -382,7 +387,7 @@ def _link_storage_element(owner: suite.Package, element: suite.StorageElement, p
             persist_as = str(Path(relpath(abspath(path), directory)).with_suffix(''))
         else:
             persist_as = ''
-        unit = _create_unit(model, str(path), persist_as)
+        unit = _create_unit(model, path, persist_as)
         element.storage_unit = unit
         _modified_files.add(unit)
     else:
@@ -420,7 +425,8 @@ def _link_pendings():
     global _pending_links
 
     for object_, role, link in _pending_links:
-        _scade_api.set(object_, role, link)
+        # _scade_api is a CPython module defined dynamically
+        _scade_api.set(object_, role, link)  # type: ignore
     _pending_links = []
 
 

--- a/src/ansys/scade/apitools/create/scade.py
+++ b/src/ansys/scade/apitools/create/scade.py
@@ -390,8 +390,6 @@ def _link_storage_element(
         unit = _create_unit(model, path, persist_as)
         element.storage_unit = unit
         _modified_files.add(unit)
-    else:
-        assert owner != model
     if owner != model:
         _set_modified(owner)
 

--- a/src/ansys/scade/apitools/create/type.py
+++ b/src/ansys/scade/apitools/create/type.py
@@ -241,7 +241,7 @@ def create_table(dimensions: Union[EX, List[EX]], type_: TX) -> TT:
     return _Table(dimensions, type_)
 
 
-def create_structure(*fields: List[Tuple[str, TX]]) -> TT:
+def create_structure(*fields: Tuple[str, TX]) -> TT:
     """
     Get the type tree for a structure.
 
@@ -252,7 +252,7 @@ def create_structure(*fields: List[Tuple[str, TX]]) -> TT:
 
     Parameters
     ----------
-    fields : List[Tuple[str, TX]]
+    *fields : Tuple[str, TX]
         Name/type expression trees.
 
     Returns
@@ -261,8 +261,8 @@ def create_structure(*fields: List[Tuple[str, TX]]) -> TT:
     """
     if len(fields) == 0:
         raise _syntax_error('create_structure', fields)
-    fields = [(_[0], _normalize_tree(_[1])) for _ in fields]
-    return _Structure(fields)
+    normalized_fields = [(_[0], _normalize_tree(_[1])) for _ in fields]
+    return _Structure(normalized_fields)
 
 
 # ----------------------------------------------------------------------------

--- a/src/ansys/scade/apitools/create/type.py
+++ b/src/ansys/scade/apitools/create/type.py
@@ -242,7 +242,7 @@ def create_table(dimensions: Union[EX, List[EX]], type_: TX) -> TT:
 
 
 def create_structure(*fields: Tuple[str, TX]) -> TT:
-    """
+    r"""
     Get the type tree for a structure.
 
     Notes
@@ -252,7 +252,7 @@ def create_structure(*fields: Tuple[str, TX]) -> TT:
 
     Parameters
     ----------
-    *fields : Tuple[str, TX]
+    \*fields : Tuple[str, TX]
         Name/type expression trees.
 
     Returns

--- a/src/ansys/scade/apitools/create/type.py
+++ b/src/ansys/scade/apitools/create/type.py
@@ -44,6 +44,7 @@ Notes: The typing is relaxed in this module to ease the constructs.
 
 """
 
+from abc import ABC, abstractmethod
 from typing import List, Tuple, Union
 
 import scade.model.suite as suite
@@ -53,13 +54,13 @@ from .scade import _add_pending_link, _get_owner_model
 
 
 # type trees
-class TypeTree:
+class TypeTree(ABC):
     """Provides the top-level abstract class for type trees."""
 
+    @abstractmethod
     def _build_type(self, context: suite.Object) -> suite.Type:
         """Build a SCADE Suite type from the type tree."""
-        # must be overridden
-        assert False  # pragma no cover
+        raise NotImplementedError  # pragma no cover
 
 
 TT = TypeTree

--- a/src/ansys/scade/apitools/expr/access.py
+++ b/src/ansys/scade/apitools/expr/access.py
@@ -310,7 +310,7 @@ class TransposeOp(ArrayOp):
         """Initialize the instance from the Scade expression."""
         assert Eck(expression.predef_opr) == Eck.TRANSPOSE
         super().__init__(expression)
-        self._dimensions = (accessor(expression.parameters[1]), expression.parameters[2])
+        self._dimensions = (accessor(expression.parameters[1]), accessor(expression.parameters[2]))
 
     @property
     def dimensions(self) -> tuple[Expression, Expression]:

--- a/src/ansys/scade/apitools/expr/access.py
+++ b/src/ansys/scade/apitools/expr/access.py
@@ -73,7 +73,7 @@ class Present(Expression):
 
     def __init__(self, expression: suite.ExprId):
         """Initialize the instance from the Scade expression."""
-        assert expression.reference and expression.reference.is_signal()
+        # assert expression.reference and expression.reference.is_signal()
         super().__init__(expression)
 
     @property
@@ -98,7 +98,7 @@ class Last(Expression):
 
     def __init__(self, expression: suite.ExprId):
         """Initialize the instance from the Scade expression."""
-        assert expression.last
+        # assert expression.last
         super().__init__(expression)
 
     @property
@@ -236,7 +236,7 @@ class DataStructOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.BLD_STRUCT
+        # assert Eck(expression.predef_opr) == Eck.BLD_STRUCT
         super().__init__(expression)
         self._data = [LabelledExpression(_.label.name, accessor(_)) for _ in expression.parameters]
 
@@ -262,7 +262,7 @@ class DataArrayOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.BLD_VECTOR
+        # assert Eck(expression.predef_opr) == Eck.BLD_VECTOR
         super().__init__(expression)
         self._data = [accessor(_) for _ in expression.parameters]
 
@@ -284,7 +284,7 @@ class ArrayOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) in {Eck.TRANSPOSE, Eck.SLICE, Eck.PRJ_DYN}
+        # assert Eck(expression.predef_opr) in {Eck.TRANSPOSE, Eck.SLICE, Eck.PRJ_DYN}
         super().__init__(expression)
         self._array = accessor(expression.parameters[0])
 
@@ -308,7 +308,7 @@ class TransposeOp(ArrayOp):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.TRANSPOSE
+        # assert Eck(expression.predef_opr) == Eck.TRANSPOSE
         super().__init__(expression)
         self._dimensions = (accessor(expression.parameters[1]), accessor(expression.parameters[2]))
 
@@ -332,7 +332,7 @@ class SliceOp(ArrayOp):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.SLICE
+        # assert Eck(expression.predef_opr) == Eck.SLICE
         super().__init__(expression)
         self._from_index = accessor(expression.parameters[1])
         self._to_index = accessor(expression.parameters[2])
@@ -383,7 +383,7 @@ class PrjDynOp(ArrayOp):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.PRJ_DYN
+        # assert Eck(expression.predef_opr) == Eck.PRJ_DYN
         super().__init__(expression)
         # the indexes are either a label identifying a structure's
         # field or an index expression
@@ -473,7 +473,7 @@ class ScalarToVectorOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.SCALAR_TO_VECTOR
+        # assert Eck(expression.predef_opr) == Eck.SCALAR_TO_VECTOR
         super().__init__(expression)
         # the last parameter is the size
         self._flows = [accessor(_) for _ in expression.parameters[:-1]]
@@ -511,7 +511,7 @@ class ProjectionOp(FlowOp):
         with_expressions: list[suite.Expression],
     ):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) in {Eck.PRJ, Eck.CHANGE_ITH}
+        # assert Eck(expression.predef_opr) in {Eck.PRJ, Eck.CHANGE_ITH}
         super().__init__(expression, flow)
         # the indexes are either a label identifying a structure's
         # field or an index expression
@@ -546,7 +546,7 @@ class PrjOp(ProjectionOp):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.PRJ
+        # assert Eck(expression.predef_opr) == Eck.PRJ
         super().__init__(expression, expression.parameters[0], expression.parameters[1:])
 
 
@@ -564,7 +564,7 @@ class ChgIthOp(ProjectionOp):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.CHANGE_ITH
+        # assert Eck(expression.predef_opr) == Eck.CHANGE_ITH
         super().__init__(expression, expression.parameters[0], expression.parameters[2:])
         self._value = accessor(expression.parameters[1])
 
@@ -595,7 +595,7 @@ class MakeOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.MAKE
+        # assert Eck(expression.predef_opr) == Eck.MAKE
         super().__init__(expression)
         self._flows = [accessor(_) for _ in expression.parameters[0].parameters]
         self._type = expression.parameters[1].reference
@@ -632,7 +632,7 @@ class FlattenOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.FLATTEN
+        # assert Eck(expression.predef_opr) == Eck.FLATTEN
         super().__init__(expression)
         self._flow = accessor(expression.parameters[0])
         self._type = expression.parameters[1].reference
@@ -685,7 +685,7 @@ class UnaryOp(AryOp):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert len(expression.parameters) == 1
+        # assert len(expression.parameters) == 1
         super().__init__(expression)
         self._operand = accessor(expression.parameters[0])
 
@@ -721,7 +721,7 @@ class NAryOp(AryOp):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert len(expression.parameters) >= 2
+        # assert len(expression.parameters) >= 2
         super().__init__(expression)
         self._operands = [accessor(_) for _ in expression.parameters]
 
@@ -752,7 +752,7 @@ class BinaryOp(NAryOp):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert len(expression.parameters) == 2
+        # assert len(expression.parameters) == 2
         super().__init__(expression)
 
 
@@ -770,9 +770,8 @@ class NumericCastOp(FlowOp):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert len(expression.parameters) == 2 and isinstance(
-            expression.parameters[1], suite.ExprType
-        )
+        # assert len(expression.parameters) == 2
+        assert isinstance(expression.parameters[1], suite.ExprType)  # nosec B101  # addresses linter
         super().__init__(expression, expression.parameters[0])
         self._type = expression.parameters[1].type
 
@@ -798,7 +797,7 @@ class SharpOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert len(expression.parameters) >= 2
+        # assert len(expression.parameters) >= 2
         super().__init__(expression)
         self._flows = [accessor(_) for _ in expression.parameters]
 
@@ -831,7 +830,7 @@ class IfThenElseOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.IF
+        # assert Eck(expression.predef_opr) == Eck.IF
         super().__init__(expression)
         self._if = accessor(expression.parameters[0])
         self._then = [accessor(_) for _ in expression.parameters[1].parameters]
@@ -884,7 +883,7 @@ class CaseOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.CASE
+        # assert Eck(expression.predef_opr) == Eck.CASE
         super().__init__(expression)
         self._switch = accessor(expression.parameters[0])
         flows = [accessor(_) for _ in expression.parameters[1].parameters]
@@ -932,7 +931,7 @@ class InitOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert len(expression.parameters) == 2 and Eck(expression.predef_opr) == Eck.FOLLOW
+        # assert len(expression.parameters) == 2 and Eck(expression.predef_opr) == Eck.FOLLOW
         super().__init__(expression)
         self._flows = [accessor(_) for _ in expression.parameters[0].parameters]
         self._inits = [accessor(_) for _ in expression.parameters[1].parameters]
@@ -971,7 +970,7 @@ class PreOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert Eck(expression.predef_opr) == Eck.PRE
+        # assert Eck(expression.predef_opr) == Eck.PRE
         super().__init__(expression)
         self._flows = [accessor(_) for _ in expression.parameters]
 
@@ -997,7 +996,7 @@ class FbyOp(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert len(expression.parameters) >= 3 and Eck(expression.predef_opr) == Eck.FBY
+        # assert len(expression.parameters) >= 3 and Eck(expression.predef_opr) == Eck.FBY
         super().__init__(expression)
         n = int((len(expression.parameters) - 1) / 2)
         self._flows = [accessor(_) for _ in expression.parameters[:n]]
@@ -1040,7 +1039,7 @@ class OpCall(CallExpression):
 
     def __init__(self, expression: suite.ExprCall):
         """Initialize the instance from the Scade expression."""
-        assert expression.operator
+        # assert expression.operator
         super().__init__(expression)
         self._call_parameters = [accessor(_) for _ in expression.parameters]
         self._instance_parameters = [accessor(_) for _ in expression.inst_parameters]
@@ -1253,10 +1252,10 @@ class PartialIteratorOp(IteratorOp):
         self._if = accessor(expression.parameters[1 + offset])
         # following might be empty when not MAP*W*
         if len(expression.parameters) == 3 + offset:
-            assert self.code in {Eck.MAPW, Eck.MAPWI, Eck.MAPFOLDW, Eck.MAPFOLDWI}
+            # assert self.code in {Eck.MAPW, Eck.MAPWI, Eck.MAPFOLDW, Eck.MAPFOLDWI}
             self._defaults = [accessor(_) for _ in expression.parameters[2 + offset].parameters]
         else:
-            assert self.code in {Eck.FOLDW, Eck.FOLDWI}
+            # assert self.code in {Eck.FOLDW, Eck.FOLDWI}
             self._defaults = None
 
     @property
@@ -1397,7 +1396,7 @@ def accessor(expression: suite.Expression) -> Expression:
     if isinstance(expression, suite.ExprType):
         raise ValueError('Type sub-expressions not supported')
 
-    assert isinstance(expression, suite.ExprCall)
+    assert isinstance(expression, suite.ExprCall)  # nosec B101  # addresses linter
     if expression.operator:
         call = OpCall(expression)
     else:

--- a/src/ansys/scade/apitools/info/runtime.py
+++ b/src/ansys/scade/apitools/info/runtime.py
@@ -39,7 +39,8 @@ def ide_print(*args, sep=' ', end='\n', file=sys.stdout, flush=False):
         if end is None:
             end = '\n'
         text = sep.join([str(_) for _ in args])
-        scade.output(text + end)
+        # scade.output is defined dynamically
+        scade.output(text + end)  # type: ignore
     else:
         builtins.print(*args, sep, end, file, flush)
 

--- a/src/ansys/scade/apitools/prop/pragma.py
+++ b/src/ansys/scade/apitools/prop/pragma.py
@@ -46,6 +46,7 @@ Notes\:
 """
 
 import json
+from typing import Optional
 
 import scade.model.suite as suite
 
@@ -96,7 +97,9 @@ def remove_pragma(object_: suite.Object, id: str) -> bool:
     # the modification status
     pragma = object_.find_pragma(id)
     if pragma:
-        pragma.object = None
+        # remove the pragma from its owner
+        # None is a legal value for the underlying implementation
+        pragma.object = None  # type: ignore
         return True
     return False
 
@@ -186,7 +189,7 @@ def set_pragma_text(object_: suite.Object, id: str, text: str) -> bool:
 # Accessors for tool pragmas
 
 
-def find_pragma_tool(object_: suite.Object, id: str, key: str) -> suite.TextPragma:
+def find_pragma_tool(object_: suite.Object, id: str, key: str) -> Optional[suite.TextPragma]:
     r"""
     Get the pragma for an object.
 
@@ -239,12 +242,14 @@ def remove_pragma_tool(object_: suite.Object, id: str, key: str) -> bool:
     """
     pragma = find_pragma_tool(object_, id, key)
     if pragma:
-        pragma.object = None
+        # remove the pragma from its owner
+        # None is a legal value for the underlying implementation
+        pragma.object = None  # type: ignore
         return True
     return False
 
 
-def get_pragma_tool_text(object_: suite.Object, id: str, key: str) -> str:
+def get_pragma_tool_text(object_: suite.Object, id: str, key: str) -> Optional[str]:
     r"""
     Get the text of the pragma for an object.
 

--- a/tests/sandbox.py
+++ b/tests/sandbox.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         name = 'ChildPackagePackageUpperFolder'
         path = _get_path(project, 'NewChildPackageUpperFolder.xscade')
         package = create.create_package(owner, name, path)
-        create.add_unit_to_project(project, package.defined_in, folder=None, default=True)
+        create.add_element_to_project(project, package, folder=None, default=True)
         # the created package must be accessible
         package_path = '%s%s::' % (owner.get_full_path(), name)
         print('package_path', package_path)

--- a/tests/test_create_data_def.py
+++ b/tests/test_create_data_def.py
@@ -36,6 +36,9 @@ to some expected result, nor easy to maintain.
 Anyways, the result models can be exmined after the execution of the tests, for a deep analysis.
 """
 
+# ignore F401: used in type annotations as `# type` comments
+from typing import List, Tuple  # noqa: F401
+
 import pytest
 
 import ansys.scade.apitools.create as create
@@ -201,8 +204,8 @@ class TestCreateDataDef:
         tree = create.create_if(cond, [a, b], [c, d])
         # graphical part
         diagram = scope.presentation_element.diagram
-        position = [13864, 4763]
-        size = [1006, 979]
+        position = (13864, 4763)
+        size = (1006, 979)
         equation = create.add_data_def_equation(scope, diagram, [l1, l2], tree, position, size)
 
         # input edges: the source equation is the unique one defining the variable
@@ -303,7 +306,7 @@ class TestCreateDataDef:
         equation = create.add_data_def_equation(scope, None, [o], i)
         # minimal test
         assert equation.to_string() == 'out = in'
-        # take the opportunity if this test case to create an assertion
+        # take the opportunity of this test case to create an assertion
         assertion = create.add_data_def_assertion(scope, None, 'AssumeFalse', False)
         assert assertion.to_string() == 'assume AssumeFalse : false'
 
@@ -320,16 +323,16 @@ class TestCreateDataDef:
         scope = model.get_object_from_path(path)
         diagram = next((_ for _ in scope.diagrams if _.name == 'Misc'))
         # source equation, with default values for textual expression
-        position = [3201, 2355]
-        size = [212, 317]
+        position = (3201, 2355)
+        size = (212, 317)
         src = create.add_data_def_equation(scope, diagram, ['bool'], True, position, size)
         left = src.lefts[0]
         assert left.is_internal()
         # minimal test
         assert src.to_string() == '%s = true' % left.name
         # target equation, with default values for terminator
-        position = [7832, 2222]
-        size = [503, 503]
+        position = (7832, 2222)
+        size = (503, 503)
         dst = create.add_data_def_equation(scope, diagram, '_', left, position, size)
         assert dst.terminator
         # minimal test
@@ -338,7 +341,7 @@ class TestCreateDataDef:
         edges = create.add_diagram_missing_edges(diagram)
         assert len(edges) == 1
         # take the opportunity if this test case to create an assertion
-        position = [1799, 3361]
+        position = (1799, 3361)
         assertion = create.add_data_def_assertion(scope, diagram, 'A1', True, position=position)
         assert assertion.to_string() == 'assume A1 : true'
 
@@ -364,13 +367,13 @@ class TestCreateDataDef:
             scope = scope.action
         diagram = next((_ for _ in scope.diagrams if _.name == name)) if name else None
         # hard coded SM with three states
-        position = [500, 500]
-        size = [15000, 9000]
+        position = (500, 500)
+        size = (15000, 9000)
         name = 'SM%s' % diagram.name.replace('Diagram', '') if diagram else 'SM'
         sm = create.add_data_def_state_machine(scope, name, diagram, position, size)
         # states
-        positions = [[6000, 1000], [1000, 7000], [11000, 7000]]
-        size = [4000, 2000]
+        positions = [(6000, 1000), (1000, 7000), (11000, 7000)]
+        size = (4000, 2000)
         states = []
         for kind, display, position in zip(create.SK, create.DK, positions):
             state = create.add_state_machine_state(sm, kind.value, position, size, kind, display)
@@ -390,7 +393,7 @@ class TestCreateDataDef:
         # create a transition from initial to final
         # let the tool compute default positions/size for the label
         # no help from the tool for the points, we must provide consistent positions
-        points = [(5000, 8000), (7000, 7000), (9000, 9000), (11000, 8000)]
+        points = [(5000, 8000), (7000, 7000), (9000, 9000), (11000, 8000)]  # type: List[Tuple[float, float]]
         tree = create.create_transition_state(True, final, False, 1, points, polyline=False)
         create.add_state_transition(initial, create.TK.STRONG, tree)
 
@@ -439,16 +442,16 @@ class TestCreateDataDef:
         # retrieve the variable used for the selector
         e = session.model.get_object_from_path('P::WhenBlocks/e/')
         # create the branches
-        positions = [[2300, 2000], [7000, 3500], [2300, 4500]]
-        size = [4000, 1000]
+        positions = [(2300, 2000), (7000, 3500), (2300, 4500)]
+        size = (4000, 1000)
         branches = []
         for pattern, display, position in zip(e.type.type.values, create.DK, positions):
             branch = create.create_when_branch(pattern.name, position, size, display)
             branches.append(branch)
         # create the block with two branches
         name = 'WB%s' % diagram.name.replace('Diagram', '') if diagram else 'WB'
-        block_position = [500, 500]
-        block_size = [11000, 6000]
+        block_position = (500, 500)
+        block_size = (11000, 6000)
         block = create.add_data_def_when_block(
             scope, name, e, branches[:2], diagram, block_position, block_size
         )

--- a/tests/test_create_declaration.py
+++ b/tests/test_create_declaration.py
@@ -38,6 +38,7 @@ Anyways, the result models can be exmined after the execution of the tests, for 
 
 from os.path import abspath
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -53,7 +54,7 @@ from ansys.scade.apitools.create.project import std
 from test_utils import get_resources_dir
 
 
-def _get_path(project: std.Project, rel_path: str) -> Path:
+def _get_path(project: std.Project, rel_path: str) -> Optional[Path]:
     """Return the absolute path with respect to the project and make sure the directory exists."""
     if rel_path:
         path = Path(abspath(Path(project.pathname).parent / rel_path))

--- a/tests/test_create_type.py
+++ b/tests/test_create_type.py
@@ -37,6 +37,8 @@ Note: Most of the functions of the module are tested though calls to higher
 level functions and thus, are not addressed here.
 """
 
+from typing import List, Union
+
 import pytest
 
 import ansys.scade.apitools.create as create
@@ -45,7 +47,7 @@ from ansys.scade.apitools.create.type import TX, _build_type, _normalize_tree
 from test_utils import get_resources_dir
 
 
-def _pre_process_type_tree(model, tree):
+def _pre_process_type_tree(model, tree: Union[TX, List[TX]]) -> Union[TX, List[TX]]:
     """Replace all occurrences of '@path' by the corresponding model element."""
     if isinstance(tree, list):
         return [_pre_process_type_tree(model, _) for _ in tree]
@@ -180,7 +182,7 @@ class TestCreateType:
     ids = [str(_[0]) for _ in build_type_data]
 
     @pytest.mark.parametrize('tree, expected', build_type_data, ids=ids)
-    def test_build_type(self, project_session, tree, expected):
+    def test_build_type(self, project_session, tree: str, expected):
         _, session = project_session
         tree = _pre_process_type_tree(session.model, tree)
         if isinstance(expected, str):
@@ -189,4 +191,4 @@ class TestCreateType:
         else:
             # robustness
             with pytest.raises(expected):
-                tree = _normalize_tree(tree)
+                _ = _normalize_tree(tree)

--- a/tests/test_query_type.py
+++ b/tests/test_query_type.py
@@ -49,7 +49,7 @@ def model():
     return load_session(pathname).model
 
 
-def format_test_data(data: list) -> tuple:
+def format_test_data(data: list):
     """Add an id to each data, assuming the first element is a Scade path."""
     return [pytest.param(*_, id=_[0].split(':')[-1].strip('/')) for _ in data]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,14 +23,12 @@
 """Helpers for test_*.py."""
 
 import difflib
-from inspect import getsourcefile
-import os
 from pathlib import Path
 
 
 def get_resources_dir() -> Path:
     """Return the directory ./resources relative to this file's directory."""
-    script_path = Path(os.path.abspath(getsourcefile(lambda: 0)))
+    script_path = Path(__file__)
     return script_path.parent
 
 


### PR DESCRIPTION
Most popular addressed patterns:
* Add `Optional` annotation to keyword argument types which default value is `None`.
* Usage of functions defined dynamically such as `scade.xxx` : add `# type: ignore`.
* Usage of incorrect or incomplete annotated SCADE Python APIs, such as `get_roots`: add type annotation for the result or `add # type: ignore`.
* Replace `*args: List[Any]` by `*args: Any`.
* Introduce new local variables do that their type remains stable. For example, replace `xxx = _normalize_tree(xxx)` by `norm_xxx = _normalize_tree(xxx)`.
* Replace tuple parameter declaration such as `Optional[Tuple[float, float]] = None` by `Tuple[float, float] = (0, 0)`. This pattern is left unchanged for lists.

These changes imply some modifications in the library, as well in the client code: tests and examples.

Fix: `TransposeOp` accessor's dimensions are correctly computed.