### PR TITLE
fix: do not add `_`pattern to case constructs with default.

### DIFF
--- a/doc/changelog.d/118.miscellaneous.md
+++ b/doc/changelog.d/118.miscellaneous.md
@@ -1,0 +1,1 @@
+Fix: do not add `_`pattern to case constructs with default.

--- a/src/ansys/scade/apitools/create/expression.py
+++ b/src/ansys/scade/apitools/create/expression.py
@@ -516,7 +516,6 @@ def create_case(selector: EX, cases: List[Tuple[EX, EX]], default: EX = None) ->
         patterns.append(_normalize_tree(pattern))
         inputs.append(_normalize_tree(input))
     if default:
-        patterns.append(_normalize_tree('_'))
         inputs.append(_normalize_tree(default))
     pattern_tree = _create_sequence(patterns)
     input_tree = _create_sequence(inputs)


### PR DESCRIPTION
Closes #116 .